### PR TITLE
[Common] ErrorCode 응답 핸들러 골격 작성

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/AuthException.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/AuthException.java
@@ -1,0 +1,15 @@
+package com.delivery.igo.igo_delivery.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public AuthException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
@@ -1,4 +1,43 @@
 package com.delivery.igo.igo_delivery.common.exception;
 
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 예외 코드 모음 - Enum
+ */
+@Getter
 public enum ErrorCode {
+
+    // Common -> default 용도
+    DUPLICATED(HttpStatus.BAD_REQUEST, "중복 되었습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "잘못된 접근입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "대상을 찾을 수 없습니다."),
+
+    // Auth
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인 실패, 아이디나 비밀번호를 확인해 주세요."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다. 로그인 후 시도해 주세요."),
+    LOGIN_FAILED_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호를 확인해 주세요."),
+
+    // Valid
+    VALID_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 입력값 입니다."),
+
+    // Order
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
+
+    // User
+    DUPLICATED_USERNAME(HttpStatus.BAD_REQUEST, "사용자 이름이 중복되었습니다. 다른 이름으로 가입해 주세요."),
+    DUPLICATED_USER(HttpStatus.BAD_REQUEST, "사용자 이름이나 email이 이미 등록되어있습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    // CartItem
+    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorDto.java
@@ -1,0 +1,15 @@
+package com.delivery.igo.igo_delivery.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ErrorDto {
+    private final int statusCode;
+    private final String message;
+    private final LocalDateTime errorTime;
+    private final String path;
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalException.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalException.java
@@ -1,0 +1,15 @@
+package com.delivery.igo.igo_delivery.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class GlobalException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public GlobalException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalExceptionHandler.java
@@ -18,6 +18,27 @@ import java.util.stream.Collectors;
 public class GlobalExceptionHandler {
 
     /**
+     * 공통 예외 응답
+     *
+     * @param e GlobalException
+     * @param request 서블릿 요청
+     * @return ErrorDto, 상태코드
+     */
+    @ExceptionHandler
+    public ResponseEntity<ErrorDto> globalException(GlobalException e, HttpServletRequest request) {
+        log.error("[globalException] ex: ", e);
+        ErrorCode errorCode = e.getErrorCode();
+
+        ErrorDto errorDto = new ErrorDto(
+                errorCode.getHttpStatus().value(),
+                errorCode.getMessage(),
+                LocalDateTime.now(),
+                request.getRequestURI());
+
+        return new ResponseEntity<>(errorDto, errorCode.getHttpStatus());
+    }
+
+    /**
      * 인증 실패 시 발생하는 예외 응답
      *
      * @param e AuthException
@@ -62,4 +83,6 @@ public class GlobalExceptionHandler {
                 request.getRequestURI());
         return new ResponseEntity<>(errorDto, ErrorCode.VALID_BAD_REQUEST.getHttpStatus());
     }
+
+
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,65 @@
 package com.delivery.igo.igo_delivery.common.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    /**
+     * 인증 실패 시 발생하는 예외 응답
+     *
+     * @param e AuthException
+     * @param request 서블릿 요청
+     * @return ErrorDto, 상태코드
+     */
+    @ExceptionHandler
+    public ResponseEntity<ErrorDto> authFailedException(AuthException e, HttpServletRequest request) {
+        log.error("[authFiledException] ex: ", e);
+        ErrorCode errorCode = e.getErrorCode();
+
+        ErrorDto errorDto = new ErrorDto(
+                errorCode.getHttpStatus().value(),
+                errorCode.getMessage(),
+                LocalDateTime.now(),
+                request.getRequestURI());
+
+        return new ResponseEntity<>(errorDto, errorCode.getHttpStatus());
+    }
+
+    /**
+     * 입력값 검증 예외 응답(빈 벨리데이션 예외시)
+     *
+     * @param e Bean Validation 예외
+     * @param request 서블릿
+     * @return ErrorDto, 400 상태코드
+     */
+    @ExceptionHandler
+    public ResponseEntity<ErrorDto> inputValidException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        log.error("[inputValidException] ex: ", e);
+
+        Map<String, List<String>> errors = e.getBindingResult().getFieldErrors().stream()
+                .collect(Collectors.groupingBy(
+                        FieldError::getField,
+                        Collectors.mapping(FieldError::getDefaultMessage, Collectors.toList())
+                ));
+
+        ErrorDto errorDto = new ErrorDto(
+                ErrorCode.VALID_BAD_REQUEST.getHttpStatus().value(),
+                errors.toString(),
+                LocalDateTime.now(),
+                request.getRequestURI());
+        return new ResponseEntity<>(errorDto, ErrorCode.VALID_BAD_REQUEST.getHttpStatus());
+    }
 }


### PR DESCRIPTION
## Description
1. 예외 발생시 응답하기 위한 핸들러 작성

2. ErrorCode 관리를 위한 Enum 클래스 생성 및 DTO 생성
    - 애플리케이션 규모가 작기 때문에 예외 메시지와 상태 코드를 Enum으로 관리하여 오타 등의 휴먼에러를 방지
    - 추가적인 에러가 필요할 경우 각자 추가하여 작성


3. GlobalException 추가
    - 인증을 제외한 모든 도메인에서 발생하는 예외는 ErrorCode의 HttpStatus와 메시지를 인자로 하여 GlobalException을 발생시켜서 해당 예외를 응답
    - 사용 방법은 스크린샷 참조

** 주의점
    - 여러 인원이 ErrorCode를 한번에 추가하여 충돌이 발생할 여지가 많음
    - PR 승인 후 merge 하기 전에 충돌을 해결 후 merge 진행할 것을 권장

## Changes
1. ErrorCode Enum 클래스 생성
2. ErrorDto 생성
3. GlobalExceptionHandler 추가
4. GlobalException, AuthException 추가

## Screenshots
1. 예외 발생 시 GlobalException 사용 방법 입니다
![image](https://github.com/user-attachments/assets/3edb5ca3-78ea-4817-b1c1-bc76b31c62ac)


# Ref
- https://www.notion.so/teamsparta/1dd2dc3ef51480259a1bd01fbfc63734?p=1de2dc3ef514801fb4d9fd8d8c70e3d9&pm=s