### PR TITLE
[Auth] 회원가입, 로그인 API 개발 및 bean validation 등 관련된 추가 기능들 개발

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/controller/AuthController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/controller/AuthController.java
@@ -1,14 +1,37 @@
-//package com.delivery.igo.igo_delivery.api.auth.controller;
-//
-//import com.delivery.igo.igo_delivery.api.auth.service.AuthService;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//@RestController
-//@RequiredArgsConstructor
-//public class AuthController {
-//
-//    private final AuthService authService;
-//
-//
-//}
+package com.delivery.igo.igo_delivery.api.auth.controller;
+
+import com.delivery.igo.igo_delivery.api.auth.dto.request.LoginRequestDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.response.LoginResponseDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.response.SignupResponseDto;
+import com.delivery.igo.igo_delivery.api.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<SignupResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
+        SignupResponseDto signupResponseDto = authService.signup(requestDto);
+
+        return new ResponseEntity<>(signupResponseDto, HttpStatus.CREATED);
+    }
+
+    @PostMapping("/login")
+    public  ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto) {
+        LoginResponseDto loginResponseDto = authService.login(requestDto);
+
+        return new ResponseEntity<>(loginResponseDto, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/dto/Dto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/dto/Dto.java
@@ -1,4 +1,0 @@
-package com.delivery.igo.igo_delivery.api.auth.dto;
-
-public class Dto {
-}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/dto/request/LoginRequestDto.java
@@ -1,0 +1,20 @@
+package com.delivery.igo.igo_delivery.api.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequestDto {
+
+    @NotBlank(message = "{auth.email.notblank}")
+    @Email(message = "{auth.email.invalid}")
+    private String email;
+
+    @NotBlank(message = "{auth.password.notblank}")
+    private String password;
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/dto/request/SignupRequestDto.java
@@ -1,6 +1,7 @@
 package com.delivery.igo.igo_delivery.api.auth.dto.request;
 
-import com.delivery.igo.igo_delivery.common.annotation.Duplicate;
+import com.delivery.igo.igo_delivery.common.annotation.EmailDuplicate;
+import com.delivery.igo.igo_delivery.common.annotation.NicknameDuplicate;
 import com.delivery.igo.igo_delivery.common.annotation.Password;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -15,11 +16,11 @@ public class SignupRequestDto {
 
     @NotBlank(message = "{auth.email.notblank}")
     @Email(message = "{auth.email.invalid}")
-    @Duplicate(message = "{auth.email.duplicate}")
+    @EmailDuplicate(message = "{auth.email.duplicate}")
     private String email;
 
     @NotBlank(message = "{auth.nickname.notblank}")
-    @Duplicate(message = "{auth.nickname.duplicate}")
+    @NicknameDuplicate(message = "{auth.nickname.duplicate}")
     private String nickname;
 
     @NotBlank(message = "{auth.password.notblank}")

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/dto/request/SignupRequestDto.java
@@ -1,0 +1,37 @@
+package com.delivery.igo.igo_delivery.api.auth.dto.request;
+
+import com.delivery.igo.igo_delivery.common.annotation.Duplicate;
+import com.delivery.igo.igo_delivery.common.annotation.Password;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupRequestDto {
+
+    @NotBlank(message = "{auth.email.notblank}")
+    @Email(message = "{auth.email.invalid}")
+    @Duplicate(message = "{auth.email.duplicate}")
+    private String email;
+
+    @NotBlank(message = "{auth.nickname.notblank}")
+    @Duplicate(message = "{auth.nickname.duplicate}")
+    private String nickname;
+
+    @NotBlank(message = "{auth.password.notblank}")
+    @Password(message = "{auth.password.invalid}")
+    private String password;
+
+    @NotBlank(message = "{auth.phoneNumber.notblank}")
+    private String phoneNumber;
+
+    @NotBlank(message = "{auth.address.notblank}")
+    private String address;
+
+    @NotBlank(message = "{auth.userRole.notblank}")
+    private String userRole;
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/dto/response/LoginResponseDto.java
@@ -1,0 +1,12 @@
+package com.delivery.igo.igo_delivery.api.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponseDto {
+
+    private final String bearerToken;
+
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/dto/response/SignupResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/dto/response/SignupResponseDto.java
@@ -1,0 +1,22 @@
+package com.delivery.igo.igo_delivery.api.auth.dto.response;
+
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignupResponseDto {
+
+    private final Long id;
+    private final String email;
+    private final String nickName;
+
+    public static SignupResponseDto of (Users savedUser) {
+        return new SignupResponseDto(
+                savedUser.getId(),
+                savedUser.getEmail(),
+                savedUser.getNickname()
+        );
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/repository/AuthRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/repository/AuthRepository.java
@@ -1,4 +1,0 @@
-package com.delivery.igo.igo_delivery.api.auth.repository;
-
-public interface AuthRepository {
-}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthService.java
@@ -1,4 +1,12 @@
 package com.delivery.igo.igo_delivery.api.auth.service;
 
+import com.delivery.igo.igo_delivery.api.auth.dto.request.LoginRequestDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.response.LoginResponseDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.response.SignupResponseDto;
+
 public interface AuthService {
+    SignupResponseDto signup(SignupRequestDto signupRequest);
+
+    LoginResponseDto login(LoginRequestDto loginRequest);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
@@ -47,7 +47,6 @@ public class AuthServiceImpl implements AuthService {
         Users user = userRepository.findByEmailAndUserStatus(loginRequest.getEmail(), UserStatus.LIVE).orElseThrow(
                 () -> new AuthException(ErrorCode.USER_NOT_FOUND));
 
-        // 로그인 시 이메일과 비밀번호가 일치하지 않을 경우 401을 반환합니다.
         if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
             throw new AuthException(ErrorCode.LOGIN_FAILED);
         }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
@@ -26,11 +26,11 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public SignupResponseDto signup(SignupRequestDto requestDto) {
 
-        if (userRepository.existsByEmailAndUserStatus(requestDto.getEmail(), UserStatus.LIVE)) {
+        if (userRepository.existsByEmail(requestDto.getEmail())) {
             throw new AuthException(ErrorCode.USER_EXIST_EMAIL);
         }
 
-        if (userRepository.existsByNicknameAndUserStatus(requestDto.getNickname(), UserStatus.LIVE)) {
+        if (userRepository.existsByNickname(requestDto.getNickname())) {
             throw new AuthException(ErrorCode.USER_EXIST_NICKNAME);
         }
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
@@ -10,7 +10,6 @@ import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
 import com.delivery.igo.igo_delivery.common.config.PasswordEncoder;
 import com.delivery.igo.igo_delivery.common.exception.AuthException;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
-import com.delivery.igo.igo_delivery.common.exception.GlobalException;
 import com.delivery.igo.igo_delivery.common.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
@@ -1,0 +1,59 @@
+package com.delivery.igo.igo_delivery.api.auth.service;
+
+import com.delivery.igo.igo_delivery.api.auth.dto.request.LoginRequestDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.response.LoginResponseDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.response.SignupResponseDto;
+import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.config.PasswordEncoder;
+import com.delivery.igo.igo_delivery.common.exception.AuthException;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import com.delivery.igo.igo_delivery.common.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public SignupResponseDto signup(SignupRequestDto requestDto) {
+
+        if (userRepository.existsByEmailAndUserStatus(requestDto.getEmail(), UserStatus.LIVE)) {
+            throw new AuthException(ErrorCode.USER_EXIST_EMAIL);
+        }
+
+        if (userRepository.existsByNicknameAndUserStatus(requestDto.getNickname(), UserStatus.LIVE)) {
+            throw new AuthException(ErrorCode.USER_EXIST_NICKNAME);
+        }
+
+        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+
+        Users newUser = Users.of(requestDto, encodedPassword);
+        Users savedUser = userRepository.save(newUser);
+
+        return SignupResponseDto.of(savedUser);
+    }
+
+    @Transactional(readOnly = true)
+    public LoginResponseDto login(LoginRequestDto loginRequest) {
+        Users user = userRepository.findByEmailAndUserStatus(loginRequest.getEmail(), UserStatus.LIVE).orElseThrow(
+                () -> new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        // 로그인 시 이메일과 비밀번호가 일치하지 않을 경우 401을 반환합니다.
+        if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
+            throw new AuthException(ErrorCode.LOGIN_FAILED);
+        }
+
+        String bearerToken = jwtUtil.createToken(user);
+        return new LoginResponseDto(bearerToken);
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/UserRole.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/UserRole.java
@@ -1,5 +1,26 @@
 package com.delivery.igo.igo_delivery.api.user.entity;
 
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
 public enum UserRole {
-    ADMIN
+    ADMIN("관리자"),
+    CONSUMER("일반 계정"),
+    OWNER("사업자 계정")
+    ;
+
+    private final String role;
+
+    public static UserRole of(String role) {
+        return Arrays.stream(UserRole.values())
+                .filter(r -> r.name().equalsIgnoreCase(role))
+                .findFirst()
+                .orElseThrow(() -> new GlobalException(ErrorCode.INVALID_USER_ROLE));
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/UserStatus.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/UserStatus.java
@@ -1,5 +1,15 @@
 package com.delivery.igo.igo_delivery.api.user.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum UserStatus {
-    LIVE
+    LIVE("활성 사용자"),
+    INACTIVE("삭제된 사용자"),
+    ;
+
+    private final String description;
+
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
@@ -1,5 +1,6 @@
 package com.delivery.igo.igo_delivery.api.user.entity;
 
+import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
 import com.delivery.igo.igo_delivery.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -50,5 +51,20 @@ public class Users extends BaseEntity {
 
     public void delete() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public static Users of(SignupRequestDto signupRequestDto, String encodedPassword) {
+        UserRole userRole = UserRole.of(signupRequestDto.getUserRole());
+
+        return Users.builder()
+                .email(signupRequestDto.getEmail())
+                .nickname(signupRequestDto.getNickname())
+                .phoneNumber(signupRequestDto.getPhoneNumber())
+                .password(encodedPassword)
+                .address(signupRequestDto.getAddress())
+                .userRole(userRole)
+                .userStatus(UserStatus.LIVE)
+                .build();
+
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/repository/UserRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/repository/UserRepository.java
@@ -2,16 +2,11 @@ package com.delivery.igo.igo_delivery.api.user.repository;
 
 import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<Users, Long> {
-    // 전체 이메일 검색
-    Optional<Users> findByEmail(String email);
-
     // 유저 상태 조회
     Optional<Users> findByEmailAndUserStatus(String email, UserStatus userStatus);
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/repository/UserRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/repository/UserRepository.java
@@ -1,4 +1,23 @@
 package com.delivery.igo.igo_delivery.api.user.repository;
 
-public interface UserRepository {
+import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<Users, Long> {
+    // 전체 이메일 검색
+    Optional<Users> findByEmail(String email);
+
+    // 유저 상태 조회
+    Optional<Users> findByEmailAndUserStatus(String email, UserStatus userStatus);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByEmailAndUserStatus(String email, UserStatus userStatus);
+
+    boolean existsByNicknameAndUserStatus(String nickname, UserStatus userStatus);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/repository/UserRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/repository/UserRepository.java
@@ -11,8 +11,6 @@ public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByEmailAndUserStatus(String email, UserStatus userStatus);
 
     boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
 
-    boolean existsByEmailAndUserStatus(String email, UserStatus userStatus);
-
-    boolean existsByNicknameAndUserStatus(String nickname, UserStatus userStatus);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/annotation/Auth.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/annotation/Auth.java
@@ -1,9 +1,9 @@
-//package com.delivery.igo.igo_delivery.common.annotation;
-//
-//import java.lang.annotation.*;
-//
-//@Target(ElementType.PARAMETER)
-//@Retention(RetentionPolicy.RUNTIME)
-//@Documented
-//public @interface Auth {
-//}
+package com.delivery.igo.igo_delivery.common.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Auth {
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/annotation/Duplicate.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/annotation/Duplicate.java
@@ -1,0 +1,18 @@
+package com.delivery.igo.igo_delivery.common.annotation;
+
+import com.delivery.igo.igo_delivery.common.validation.DuplicatedValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+
+@Documented
+@Constraint(validatedBy = DuplicatedValidator.class)
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Duplicate {
+    String message();
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/annotation/EmailDuplicate.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/annotation/EmailDuplicate.java
@@ -1,0 +1,18 @@
+package com.delivery.igo.igo_delivery.common.annotation;
+
+import com.delivery.igo.igo_delivery.common.validation.EmailDuplicatedValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+
+@Documented
+@Constraint(validatedBy = EmailDuplicatedValidator.class)
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EmailDuplicate {
+    String message();
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/annotation/NicknameDuplicate.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/annotation/NicknameDuplicate.java
@@ -1,6 +1,6 @@
 package com.delivery.igo.igo_delivery.common.annotation;
 
-import com.delivery.igo.igo_delivery.common.validation.DuplicatedValidator;
+import com.delivery.igo.igo_delivery.common.validation.NicknameDuplicatedValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
@@ -8,10 +8,10 @@ import java.lang.annotation.*;
 
 
 @Documented
-@Constraint(validatedBy = DuplicatedValidator.class)
+@Constraint(validatedBy = NicknameDuplicatedValidator.class)
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Duplicate {
+public @interface NicknameDuplicate {
     String message();
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};

--- a/src/main/java/com/delivery/igo/igo_delivery/common/annotation/Password.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/annotation/Password.java
@@ -1,0 +1,18 @@
+package com.delivery.igo.igo_delivery.common.annotation;
+
+import com.delivery.igo.igo_delivery.common.validation.PasswordValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+
+@Documented
+@Constraint(validatedBy = PasswordValidator.class)
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Password {
+    String message();
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/config/AuthUserArgumentResolver.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/config/AuthUserArgumentResolver.java
@@ -1,6 +1,5 @@
 package com.delivery.igo.igo_delivery.common.config;
 
-import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
 import com.delivery.igo.igo_delivery.common.annotation.Auth;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.exception.AuthException;

--- a/src/main/java/com/delivery/igo/igo_delivery/common/config/AuthUserArgumentResolver.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/config/AuthUserArgumentResolver.java
@@ -1,56 +1,50 @@
-//package com.delivery.igo.igo_delivery.common.config;
-//
-//import com.delivery.igo.igo_delivery.common.annotation.Auth;
-//import com.delivery.igo.igo_delivery.common.dto.AuthUser;
-//import jakarta.security.auth.message.AuthException;
-//import jakarta.servlet.http.HttpServletRequest;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.core.MethodParameter;
-//import org.springframework.lang.Nullable;
-//import org.springframework.stereotype.Component;
-//import org.springframework.web.bind.support.WebDataBinderFactory;
-//import org.springframework.web.context.request.NativeWebRequest;
-//import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-//import org.springframework.web.method.support.ModelAndViewContainer;
-//
-//@Component
-//@RequiredArgsConstructor
-//public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
-//
-//    private final JwtUtil jwtUtil;
-//
-//    @Override
-//    public boolean supportsParameter(MethodParameter parameter) {
-//        boolean hasAuthAnnotation = parameter.getParameterAnnotation(Auth.class) != null;
-//        boolean isAuthUserType = parameter.getParameterType().equals(AuthUser.class);
-//
-//        // @Auth 어노테이션과 AuthUser 타입이 함께 사용되지 않은 경우 예외 발생
-//        if (hasAuthAnnotation != isAuthUserType) {
-//            throw new AuthException("@Auth와 AuthUser 타입은 함께 사용되어야 합니다.");
-//        }
-//
-//        return hasAuthAnnotation;
-//    }
-//
-//    @Override
-//    public Object resolveArgument(
-//            @Nullable MethodParameter parameter,
-//            @Nullable ModelAndViewContainer mavContainer,
-//            NativeWebRequest webRequest,
-//            @Nullable WebDataBinderFactory binderFactory
-//    ) {
-//        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-//
-////        // JwtFilter 에서 set 한 userId, email, userRole 값을 가져옴
-////        Long userId = (Long) request.getAttribute("userId");
-////        String email = (String) request.getAttribute("email");
-////        UserRole userRole = UserRole.of((String) request.getAttribute("userRole"));
-////
-////        return new AuthUser(userId, email, userRole);
-//
-//        /// jwtUtil에서 token을 활용하는 방식으로 변경하기(refactoring)
-//        String token = jwtUtil.substringToken(request.getHeader("Authorization"));
-//
-//        return new AuthUser(jwtUtil.getUserId(token), jwtUtil.getUserEmail(token), jwtUtil.getUserRole(token));
-//    }
-//}
+package com.delivery.igo.igo_delivery.common.config;
+
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.common.annotation.Auth;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.AuthException;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasAuthAnnotation = parameter.getParameterAnnotation(Auth.class) != null;
+        boolean isAuthUserType = parameter.getParameterType().equals(AuthUser.class);
+
+        // @Auth 어노테이션과 AuthUser 타입이 함께 사용되지 않은 경우 예외 발생
+        if (hasAuthAnnotation != isAuthUserType) {
+            throw new AuthException(ErrorCode.AUTH_TYPE_MISMATCH);
+        }
+
+        return hasAuthAnnotation;
+    }
+
+    @Override
+    public Object resolveArgument(
+            @Nullable MethodParameter parameter,
+            @Nullable ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            @Nullable WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        String token = jwtUtil.substringToken(request.getHeader("Authorization"));
+        return AuthUser.of(token, jwtUtil);
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/config/FilterConfig.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/config/FilterConfig.java
@@ -1,22 +1,24 @@
-//package com.delivery.igo.igo_delivery.common.config;
-//
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.boot.web.servlet.FilterRegistrationBean;
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.context.annotation.Configuration;
-//
-//@Configuration
-//@RequiredArgsConstructor
-//public class FilterConfig {
-//
-//    private final JwtUtil jwtUtil;
-//
-//    @Bean
-//    public FilterRegistrationBean<JwtFilter> jwtFilter() {
-//        FilterRegistrationBean<JwtFilter> registrationBean = new FilterRegistrationBean<>();
-//        registrationBean.setFilter(new JwtFilter(jwtUtil));
-//        registrationBean.addUrlPatterns("/*"); // 필터를 적용할 URL 패턴을 지정합니다.
-//
-//        return registrationBean;
-//    }
-//}
+package com.delivery.igo.igo_delivery.common.config;
+
+import com.delivery.igo.igo_delivery.common.filter.JwtFilter;
+import com.delivery.igo.igo_delivery.common.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class FilterConfig {
+
+    private final JwtUtil jwtUtil;
+
+    @Bean
+    public FilterRegistrationBean<JwtFilter> jwtFilter() {
+        FilterRegistrationBean<JwtFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new JwtFilter(jwtUtil));
+        registrationBean.addUrlPatterns("/*");
+
+        return registrationBean;
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/config/PasswordEncoder.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/config/PasswordEncoder.java
@@ -1,17 +1,17 @@
-//package com.delivery.igo.igo_delivery.common.config;
-//
-//import at.favre.lib.crypto.bcrypt.BCrypt;
-//import org.springframework.stereotype.Component;
-//
-//@Component
-//public class PasswordEncoder {
-//
-//    public String encode(String rawPassword) {
-//        return BCrypt.withDefaults().hashToString(BCrypt.MIN_COST, rawPassword.toCharArray());
-//    }
-//
-//    public boolean matches(String rawPassword, String encodedPassword) {
-//        BCrypt.Result result = BCrypt.verifyer().verify(rawPassword.toCharArray(), encodedPassword);
-//        return result.verified;
-//    }
-//}
+package com.delivery.igo.igo_delivery.common.config;
+
+import at.favre.lib.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordEncoder {
+
+    public String encode(String rawPassword) {
+        return BCrypt.withDefaults().hashToString(BCrypt.MIN_COST, rawPassword.toCharArray());
+    }
+
+    public boolean matches(String rawPassword, String encodedPassword) {
+        BCrypt.Result result = BCrypt.verifyer().verify(rawPassword.toCharArray(), encodedPassword);
+        return result.verified;
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/config/WebConfig.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/config/WebConfig.java
@@ -1,21 +1,21 @@
-//package com.delivery.igo.igo_delivery.common.config;
-//
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-//import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-//
-//import java.util.List;
-//
-//@Configuration
-//@RequiredArgsConstructor
-//public class WebConfig implements WebMvcConfigurer {
-//
-//    private final AuthUserArgumentResolver authUserArgumentResolver;
-//
-//    // ArgumentResolver 등록
-//    @Override
-//    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-//        resolvers.add(authUserArgumentResolver);
-//    }
-//}
+package com.delivery.igo.igo_delivery.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    // ArgumentResolver 등록
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/dto/AuthUser.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/dto/AuthUser.java
@@ -1,19 +1,24 @@
-//package com.delivery.igo.igo_delivery.common.dto;
-//
-//import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
-//import lombok.Getter;
-//
-//@Getter
-//public class AuthUser {
-//
-//    private final Long id;
-//    private final String email;
-//    private final UserRole userRole;
-//
-//    public AuthUser(Long id, String email, UserRole userRole) {
-//        this.id = id;
-//        this.email = email;
-//        this.userRole = userRole;
-//    }
-//}
-//}
+package com.delivery.igo.igo_delivery.common.dto;
+
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.common.util.JwtUtil;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthUser {
+
+    private final Long id;
+    private final String email;
+    private final String nickname;
+    private final UserRole userRole;
+
+    public static AuthUser of(String token, JwtUtil jwtUtil) {
+        return new AuthUser(jwtUtil.getUserId(token),
+                jwtUtil.getUserEmail(token),
+                jwtUtil.getUserNickname(token),
+                jwtUtil.getUserRole(token));
+    }
+}
+

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/AuthException.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/AuthException.java
@@ -7,8 +7,8 @@ public class AuthException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
-    public AuthException(ErrorCode errorCode, String message) {
-        super(message);
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
@@ -17,7 +17,18 @@ public enum ErrorCode {
     // Auth
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인 실패, 아이디나 비밀번호를 확인해 주세요."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다. 로그인 후 시도해 주세요."),
-    LOGIN_FAILED_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호를 확인해 주세요."),
+    USER_EXIST_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    USER_EXIST_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
+    AUTH_TYPE_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, "@Auth와 AuthUser 타입은 함께 사용되어야 합니다."),
+
+
+    // JWT
+    JWT_REQUIRED(HttpStatus.BAD_REQUEST, "JWT 토큰이 필요합니다."),
+    JWT_BAD_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 JWT 토큰입니다."),
+    JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+    JWT_INVALID_TOKEN( HttpStatus.UNAUTHORIZED, "유효하지 않는 JWT 토큰입니다."),
+    JWT_INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "유효하지 않는 JWT 서명입니다."),
+    JWT_NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, "JWT 토큰이 없습니다"),
 
     // Valid
     VALID_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 입력값 입니다."),
@@ -29,6 +40,11 @@ public enum ErrorCode {
     DUPLICATED_USERNAME(HttpStatus.BAD_REQUEST, "사용자 이름이 중복되었습니다. 다른 이름으로 가입해 주세요."),
     DUPLICATED_USER(HttpStatus.BAD_REQUEST, "사용자 이름이나 email이 이미 등록되어있습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    USER_NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "권한 정보가 없습니다."),
+    INVALID_USER_ROLE(HttpStatus.FORBIDDEN, "유효하지 않은 사용자 권한입니다."),
+    ROLE_ADMIN_FORBIDDEN(HttpStatus.UNAUTHORIZED, "관리자 권한이 없습니다."),
+    ROLE_CONSUMER_FORBIDDEN(HttpStatus.UNAUTHORIZED, "주문 고객이 아닙니다."),
+    ROLE_OWNER_FORBIDDEN(HttpStatus.UNAUTHORIZED, "매장 사장님이 아닙니다."),
 
     // CartItem
     CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다.");

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalException.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalException.java
@@ -12,4 +12,9 @@ public class GlobalException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
+    public GlobalException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalExceptionHandler.java
@@ -47,7 +47,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler
     public ResponseEntity<ErrorDto> authFailedException(AuthException e, HttpServletRequest request) {
-        log.error("[authFiledException] ex: ", e);
+        log.error("[authFailedException] ex: ", e);
         ErrorCode errorCode = e.getErrorCode();
 
         ErrorDto errorDto = new ErrorDto(

--- a/src/main/java/com/delivery/igo/igo_delivery/common/filter/JwtFilter.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/filter/JwtFilter.java
@@ -46,7 +46,7 @@ public class JwtFilter extends OncePerRequestFilter {
         String bearerJwt = request.getHeader("Authorization");
 
         if (bearerJwt == null) {
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "JWT 토큰이 필요합니다.");
+            setErrorResponse(response, ErrorCode.JWT_REQUIRED, url);
             return;
         }
 

--- a/src/main/java/com/delivery/igo/igo_delivery/common/filter/JwtFilter.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/filter/JwtFilter.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/delivery/igo/igo_delivery/common/filter/JwtFilter.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/filter/JwtFilter.java
@@ -14,6 +14,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -31,9 +32,9 @@ public class JwtFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
 
         String url = request.getRequestURI();
 

--- a/src/main/java/com/delivery/igo/igo_delivery/common/filter/JwtFilter.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/filter/JwtFilter.java
@@ -38,7 +38,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         String url = request.getRequestURI();
 
-        if (isWhiteList(request.getRequestURI())) {
+        if (isWhiteList(url)) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/filter/JwtFilter.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/filter/JwtFilter.java
@@ -1,94 +1,108 @@
-//package com.delivery.igo.igo_delivery.common.filter;
-//
-//import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
-//import com.delivery.igo.igo_delivery.common.util.JwtUtil;
-//import io.jsonwebtoken.Claims;
-//import io.jsonwebtoken.ExpiredJwtException;
-//import io.jsonwebtoken.MalformedJwtException;
-//import io.jsonwebtoken.UnsupportedJwtException;
-//import jakarta.servlet.*;
-//import jakarta.servlet.http.HttpServletRequest;
-//import jakarta.servlet.http.HttpServletResponse;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//
-//import java.io.IOException;
-//
-//@Slf4j
-//@RequiredArgsConstructor
-//public class JwtFilter implements Filter {
-//
-//    private final JwtUtil jwtUtil;
-//
-//    @Override
-//    public void init(FilterConfig filterConfig) throws ServletException {
-//        Filter.super.init(filterConfig);
-//    }
-//
-//    @Override
-//    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-//        HttpServletRequest httpRequest = (HttpServletRequest) request;
-//        HttpServletResponse httpResponse = (HttpServletResponse) response;
-//
-//        String url = httpRequest.getRequestURI();
-//
-//        if (url.startsWith("/auth")) {
-//            chain.doFilter(request, response);
-//            return;
-//        }
-//
-//        String bearerJwt = httpRequest.getHeader("Authorization");
-//
-//        if (bearerJwt == null) {
-//            // 토큰이 없는 경우 400을 반환합니다.
-//            httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "JWT 토큰이 필요합니다.");
-//            return;
-//        }
-//
-//        String jwt = jwtUtil.substringToken(bearerJwt);
-//
-//        try {
-//            // JWT 유효성 검사와 claims 추출
-//            Claims claims = jwtUtil.extractClaims(jwt);
-//            if (claims == null) {
-//                httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "잘못된 JWT 토큰입니다.");
-//                return;
-//            }
-//
-//            UserRole userRole = UserRole.valueOf(claims.get("userRole", String.class));
-//
-//            httpRequest.setAttribute("userId", Long.parseLong(claims.getSubject()));
-//            httpRequest.setAttribute("email", claims.get("email"));
-//            httpRequest.setAttribute("userRole", claims.get("userRole"));
-//
-//            if (url.startsWith("/admin")) {
-//                // 관리자 권한이 없는 경우 403을 반환합니다.
-//                if (!UserRole.ADMIN.equals(userRole)) {
-//                    httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN, "관리자 권한이 없습니다.");
-//                    return;
-//                }
-//                chain.doFilter(request, response);
-//                return;
-//            }
-//
-//            chain.doFilter(request, response);
-//        } catch (SecurityException | MalformedJwtException e) {
-//            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.", e);
-//            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않는 JWT 서명입니다.");
-//        } catch (ExpiredJwtException e) {
-//            log.error("Expired JWT token, 만료된 JWT token 입니다.", e);
-//            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "만료된 JWT 토큰입니다.");
-//        } catch (UnsupportedJwtException e) {
-//            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.", e);
-//            httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "지원되지 않는 JWT 토큰입니다.");
-//        } catch (Exception e) {
-//            log.error("Invalid JWT token, 유효하지 않는 JWT 토큰 입니다.", e);
-//            httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "유효하지 않는 JWT 토큰입니다.");
-//        }
-//    }
-//
-//    @Override
-//    public void destroy() {
-//        Filter.super.destroy();
-//    }
-//}
+package com.delivery.igo.igo_delivery.common.filter;
+
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.ErrorDto;
+import com.delivery.igo.igo_delivery.common.util.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private static final List<String> WHITE_LIST = List.of("/auth/signup", "/auth/login");
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String url = request.getRequestURI();
+
+        if (isWhiteList(request.getRequestURI())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String bearerJwt = request.getHeader("Authorization");
+
+        if (bearerJwt == null) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "JWT 토큰이 필요합니다.");
+            return;
+        }
+
+        String jwt = jwtUtil.substringToken(bearerJwt);
+
+        try {
+            Claims claims = jwtUtil.extractClaims(jwt);
+            if (claims == null) {
+                setErrorResponse(response, ErrorCode.JWT_BAD_TOKEN, url);
+                return;
+            }
+
+            UserRole userRole = UserRole.valueOf(claims.get("userRole", String.class));
+
+            request.setAttribute("userId", Long.parseLong(claims.getSubject()));
+            request.setAttribute("email", claims.get("email"));
+            request.setAttribute("userRole", claims.get("userRole"));
+
+            if (url.startsWith("/admin") && !UserRole.ADMIN.equals(userRole)) {
+                setErrorResponse(response, ErrorCode.ROLE_ADMIN_FORBIDDEN, url);
+                return;
+            }
+
+            filterChain.doFilter(request, response);
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT signature", e);
+            setErrorResponse(response, ErrorCode.JWT_INVALID_SIGNATURE, url);
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token", e);
+            setErrorResponse(response, ErrorCode.JWT_EXPIRED, url);
+        } catch (Exception e) {
+            log.error("Invalid JWT token", e);
+            setErrorResponse(response, ErrorCode.JWT_INVALID_TOKEN, url);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode, String path) throws IOException {
+        ErrorDto errorDto = new ErrorDto(
+                errorCode.getHttpStatus().value(),
+                errorCode.getMessage(),
+                LocalDateTime.now(),
+                path
+        );
+
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        response.getWriter().write(mapper.writeValueAsString(errorDto));
+    }
+
+    private boolean isWhiteList(String uri) {
+        return WHITE_LIST.stream().anyMatch(uri::startsWith);
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/util/JwtUtil.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/util/JwtUtil.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-import java.rmi.ServerException;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;

--- a/src/main/java/com/delivery/igo/igo_delivery/common/util/JwtUtil.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/util/JwtUtil.java
@@ -1,92 +1,103 @@
-//package com.delivery.igo.igo_delivery.common.util;
-//
-//import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
-//import io.jsonwebtoken.Claims;
-//import io.jsonwebtoken.Jwts;
-//import io.jsonwebtoken.SignatureAlgorithm;
-//import io.jsonwebtoken.security.Keys;
-//import jakarta.annotation.PostConstruct;
-//import lombok.extern.slf4j.Slf4j;
-////import org.example.expert.domain.common.exception.ServerException;
-////import org.example.expert.domain.user.enums.UserRole;
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.stereotype.Component;
-//import org.springframework.util.StringUtils;
-//
-//import java.rmi.ServerException;
-//import java.security.Key;
-//import java.util.Base64;
-//import java.util.Date;
-//
-//@Slf4j(topic = "JwtUtil")
-//@Component
-//public class JwtUtil {
-//
-//    private static final String BEARER_PREFIX = "Bearer ";
-//    private static final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
-//
-//    @Value("${jwt.secret.key}")
-//    private String secretKey;
-//    private Key key;
-//    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
-//
-//    @PostConstruct
-//    public void init() {
-//        byte[] bytes = Base64.getDecoder().decode(secretKey);
-//        key = Keys.hmacShaKeyFor(bytes);
-//    }
-//
-//    public String createToken(Long userId, String email, UserRole userRole) {
-//        Date date = new Date();
-//
-//        return BEARER_PREFIX +
-//                Jwts.builder()
-//                        .setSubject(String.valueOf(userId))
-//                        .claim("email", email)
-//                        .claim("userRole", userRole)
-//                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
-//                        .setIssuedAt(date) // 발급일
-//                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
-//                        .compact();
-//    }
-//
-//    public String substringToken(String tokenValue) {
-//        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
-//            return tokenValue.substring(7);
-//        }
-//        throw new ServerException("Not Found Token");
-//    }
-//
-//    public Claims extractClaims(String token) {
-//        return Jwts.parserBuilder()
-//                .setSigningKey(key)
-//                .build()
-//                .parseClaimsJws(token)
-//                .getBody();
-//    }
-//
-//    public Long getUserId(String token) {
-//        Claims claims = extractClaims(token);
-//        return Long.valueOf(claims.getSubject());
-//    }
-//
-//    public String getUserEmail(String token) {
-//        Claims claims = extractClaims(token);
-//        return claims.get("email", String.class);
-//    }
-//
-//    public UserRole getUserRole(String token) {
-//        Claims claims = extractClaims(token);
-//        String roleString = claims.get("userRole", String.class);
-//
-//        if (roleString == null) {
-//            throw new ServerException("권한 정보가 없습니다.");
-//        }
-//
-//        try {
-//            return UserRole.valueOf(roleString);
-//        } catch (IllegalArgumentException e) {
-//            throw new ServerException("유효하지 않은 사용자 권한입니다.");
-//        }
-//    }
-//}
+package com.delivery.igo.igo_delivery.common.util;
+
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.common.exception.AuthException;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.rmi.ServerException;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j(topic = "JwtUtil")
+@Component
+public class JwtUtil {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    @Value("${jwt.expiration.access}")
+    private long tokenTimeSec;
+
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String createToken(Users savedUser) {
+        Date date = new Date();
+
+        // 토큰 발급
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(String.valueOf(savedUser.getId()))
+                        .claim("email", savedUser.getEmail())
+                        .claim("nickname", savedUser.getNickname())
+                        .claim("userRole", savedUser.getUserRole())
+                        .setExpiration(new Date(date.getTime() + tokenTimeSec * 1000))  // 만료 시간
+                        .setIssuedAt(date)                                              // 발급 시간
+                        .signWith(key, signatureAlgorithm)                              // 서명
+                        .compact();                                                     // JWT 문자열 생성
+    }
+
+    public String substringToken(String tokenValue) {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(BEARER_PREFIX.length());
+        }
+        throw new AuthException(ErrorCode.JWT_NOT_FOUND_TOKEN);
+    }
+
+    public Claims extractClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public Long getUserId(String token) {
+        Claims claims = extractClaims(token);
+        return Long.valueOf(claims.getSubject());
+    }
+
+    public String getUserNickname(String token) {
+        Claims claims = extractClaims(token);
+        return claims.get("nickname", String.class);
+    }
+
+    public String getUserEmail(String token) {
+        Claims claims = extractClaims(token);
+        return claims.get("email", String.class);
+    }
+
+    public UserRole getUserRole(String token) {
+        Claims claims = extractClaims(token);
+        String roleString = claims.get("userRole", String.class);
+
+        if (roleString == null) {
+            throw new AuthException(ErrorCode.USER_NOT_FOUND_ROLE);
+        }
+
+        try {
+            return UserRole.valueOf(roleString);
+        } catch (IllegalArgumentException e) {
+            throw new AuthException(ErrorCode.INVALID_USER_ROLE);
+        }
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/validation/DuplicatedValidator.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/validation/DuplicatedValidator.java
@@ -1,0 +1,19 @@
+package com.delivery.igo.igo_delivery.common.validation;
+
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.annotation.Duplicate;
+import com.delivery.igo.igo_delivery.common.annotation.Password;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DuplicatedValidator implements ConstraintValidator<Duplicate, String> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean isValid(String email, ConstraintValidatorContext context) {
+        return email != null && !userRepository.existsByEmail(email);
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/validation/DuplicatedValidator.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/validation/DuplicatedValidator.java
@@ -2,7 +2,6 @@ package com.delivery.igo.igo_delivery.common.validation;
 
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
 import com.delivery.igo.igo_delivery.common.annotation.Duplicate;
-import com.delivery.igo.igo_delivery.common.annotation.Password;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/delivery/igo/igo_delivery/common/validation/EmailDuplicatedValidator.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/validation/EmailDuplicatedValidator.java
@@ -1,0 +1,18 @@
+package com.delivery.igo.igo_delivery.common.validation;
+
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.annotation.EmailDuplicate;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class EmailDuplicatedValidator implements ConstraintValidator<EmailDuplicate, String> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean isValid(String email, ConstraintValidatorContext context) {
+        return email != null && !userRepository.existsByEmail(email);
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/validation/NicknameDuplicatedValidator.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/validation/NicknameDuplicatedValidator.java
@@ -12,7 +12,7 @@ public class NicknameDuplicatedValidator implements ConstraintValidator<Nickname
     private final UserRepository userRepository;
 
     @Override
-    public boolean isValid(String email, ConstraintValidatorContext context) {
-        return email != null && !userRepository.existsByNickname(email);
+    public boolean isValid(String nickname, ConstraintValidatorContext context) {
+        return nickname != null && !userRepository.existsByNickname(nickname);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/validation/NicknameDuplicatedValidator.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/validation/NicknameDuplicatedValidator.java
@@ -1,18 +1,18 @@
 package com.delivery.igo.igo_delivery.common.validation;
 
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
-import com.delivery.igo.igo_delivery.common.annotation.Duplicate;
+import com.delivery.igo.igo_delivery.common.annotation.NicknameDuplicate;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class DuplicatedValidator implements ConstraintValidator<Duplicate, String> {
+public class NicknameDuplicatedValidator implements ConstraintValidator<NicknameDuplicate, String> {
 
     private final UserRepository userRepository;
 
     @Override
     public boolean isValid(String email, ConstraintValidatorContext context) {
-        return email != null && !userRepository.existsByEmail(email);
+        return email != null && !userRepository.existsByNickname(email);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/validation/PasswordValidator.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/validation/PasswordValidator.java
@@ -1,0 +1,15 @@
+package com.delivery.igo.igo_delivery.common.validation;
+
+import com.delivery.igo.igo_delivery.common.annotation.Password;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PasswordValidator implements ConstraintValidator<Password, String> {
+
+    private static final String REGEX = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,15}$";
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value != null && value.matches(REGEX);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,5 @@ jwt.secretKey=${JWT_SECRETKEY:NySdDLWFpZNSc5M63f1GZxiUm39smM5mDqJ0X+MbGWY=}
 
 # jwt standard : UnixTime / Unit : sec.
 jwt.expiration.access=${JWT_EXPIRATION:1200}
+
+spring.messages.basename=messages

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,7 @@ spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.Ca
 
 spring.profiles.active=dev
 
-jwt.secretKey=${JWT_SECRETKEY:igo-igo-igo-igo-igo-secret-default-key}
+jwt.secretKey=${JWT_SECRETKEY:NySdDLWFpZNSc5M63f1GZxiUm39smM5mDqJ0X+MbGWY=}
 
 # jwt standard : UnixTime / Unit : sec.
 jwt.expiration.access=${JWT_EXPIRATION:1200}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,15 @@
+# 기본 메시지
+javax.validation.constraints.NotBlank.message=필수 입력 항목입니다.
+javax.validation.constraints.Email.message=이메일 형식이 올바르지 않습니다.
+
+# Auth
+auth.email.notblank=이메일을 입력해 주세요.
+auth.email.invalid=이메일 형식이 올바르지 않습니다.
+auth.email.duplicate=이미 사용 중인 이메일입니다.
+auth.password.notblank=비밀번호를 입력해 주세요.
+auth.password.invalid=비밀번호는 영문, 숫자, 특수문자를 포함한 8~15자리여야 합니다.
+auth.userRole.notblank=사용자 역할을 입력해 주세요.
+auth.nickname.notblank=닉네임을 입력해 주세요.
+auth.nickname.duplicate=이미 사용 중인 닉네임입니다.
+auth.phoneNumber.notblank=전화번호를 입력해 주세요.
+auth.address.notblank=주소를 입력해 주세요.


### PR DESCRIPTION
#### ** 충돌이 많은 PR 이므로 merge 완료 시 반드시 dev 브랜치를 개발하시는 브랜치에 merge 후 개발을 이어 나가시길 부탁 드립니다**


## Description
1. 회원가입 API 개발
     - 회원가입 시 이메일, 닉네임 중복 검증 예외 적용
     - 암호화된 비밀번호 반영 적용
     - 회원가입 성공시 201 상태코드와 userId, email, nickname 응답

2. 로그인 API 개발
    - 상태가 LIVE인 user 중 로그인 시도한 email이 없다면 유저가 없다는 예외 발생
    - 입력한 비밀번호의 검증이 실패하면 예외 발생
    - 로그인 성공시 AccessToken 발급

3. bean validation 관련
    - @Password, @Duplicated 처럼 비밀번호검증과 중복 검증을하는 커스텀 애노테이션 적용
    - message.properties 를 적용하여 bean validation 예외 시 응답하는 메시지를 관리하도록 적용

4. jwt 세팅 관련
    - application.properties에 작성된 secretKey에 적용된 -(하이푼)은 Base64.getDecoder()로 디코딩 될 수 없으므로 시크릿 키 수정
    - Jwt이 정상적으로 적용되도록 관련 코드들 적용

5. @AuthUser 관련
    - 해당 애노테이션이 정상 동작하도록 AuthUserArgumentResolver 작성

6. 기타 불필요한 코드 및 주석 제거


## Changes
1. auth
    - AuthController, AuthService, AuthServiceImpl 수정
    - 로그인, 회원가입 관련 비즈니스 로직 추가
    - SignupResponseDto 정적 팩토리 메서드 추가

2. users
    - UserRepository에 메서드 이름 쿼리 등 추가
    - UserRole, UserStatus에 값 추가
    - Users 정적 팩토리 메서드 추가

3. bean valication 관련
    - annotation패키지: 커스텀 애노테이션 추가
    - validation패키지: 커스텀 애노테이션 동작하는 코드
    - message.properties 추가

4. config
    - AuthUserArgumentResolver, FilterConfig, WebConfig 수정

5. jwt
    - JwtFilter, JwtUtil, FilterConfig, WebConfig 수정
    - application.properties에 시크릿키 수정

8. AuthUser
    - AuthUser에 nickname 필드 추가
    - 정적 팩토리 메서드 추가

9. exception
    - Errorcode: 인증관련된 에러코드들 추가


## Screenshots
1. 회원 가입 성공
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/f40ab84c-80af-47c4-bd20-9ac3d37cbbdc" />


11. 로그인 성공
<img width="975" alt="image" src="https://github.com/user-attachments/assets/ccc75379-8206-4616-ad0c-10ef630026dd" />


## Ref
![image](https://github.com/user-attachments/assets/1ea259a3-6696-401b-bab6-46dc63b43033)