### PR TITLE
 [Auth] 회원 가입 시 해당 회원의 장바구니 생성

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
@@ -4,6 +4,8 @@ import com.delivery.igo.igo_delivery.api.auth.dto.request.LoginRequestDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.response.LoginResponseDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.response.SignupResponseDto;
+import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
+import com.delivery.igo.igo_delivery.api.cart.repository.CartRepository;
 import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
@@ -22,6 +24,7 @@ public class AuthServiceImpl implements AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final CartRepository cartRepository;
 
     @Transactional
     public SignupResponseDto signup(SignupRequestDto requestDto) {
@@ -38,6 +41,8 @@ public class AuthServiceImpl implements AuthService {
 
         Users newUser = Users.of(requestDto, encodedPassword);
         Users savedUser = userRepository.save(newUser);
+
+        cartRepository.save(new Carts(savedUser));
 
         return SignupResponseDto.of(savedUser);
     }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/entity/Carts.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/entity/Carts.java
@@ -26,4 +26,7 @@ public class Carts extends BaseEntity {
     @JoinColumn(name = "users_id", nullable = false)
     private Users users;
 
+    public Carts(Users users){
+        this.users = users;
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/repository/CartRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/repository/CartRepository.java
@@ -1,0 +1,14 @@
+package com.delivery.igo.igo_delivery.api.cart.repository;
+
+import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartRepository extends JpaRepository<Carts, Long> {
+
+    Carts findByUsersId(Long userId);
+
+    Optional<Carts> findByUsers(Users users);
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/repository/OrderRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/repository/OrderRepository.java
@@ -1,4 +1,0 @@
-package com.delivery.igo.igo_delivery.api.cart.repository;
-
-public interface OrderRepository {
-}


### PR DESCRIPTION
## Description
- 장바구니 DB를 회원당 하나씩 자동으로 소유하도록 추가했습니다.
- 회원가입시 생성된 장바구니는 회원 탈퇴시 까지 유지됩니다.

## Changes
- 관련 repository를 생성했습니다.
- Carts entity에 생성자를 추가했습니다.

## Screenshots
![image](https://github.com/user-attachments/assets/36b92a1c-d704-48cb-ae8e-b660bcbbb8b7)

회원 생성 시 carts 테이블에 데이터가 추가된 화면
