### PR TITLE
[Menu] 메뉴 생성 API 개발 및 테스트 코드

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/controller/MenuController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/controller/MenuController.java
@@ -7,6 +7,7 @@ import com.delivery.igo.igo_delivery.common.annotation.Auth;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,6 +26,8 @@ public class MenuController {
     public ResponseEntity<MenuResponseDto> createMenu(@Auth AuthUser authUser, @PathVariable Long storesId,
                                                       @Valid @RequestBody MenuRequestDto requestDto) {
 
-        menuService.createMenu(authUser, storesId, requestDto);
+        MenuResponseDto menu = menuService.createMenu(authUser, storesId, requestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(menu);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/controller/MenuController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/controller/MenuController.java
@@ -1,4 +1,30 @@
 package com.delivery.igo.igo_delivery.api.menu.controller;
 
+import com.delivery.igo.igo_delivery.api.menu.dto.request.MenuRequestDto;
+import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuResponseDto;
+import com.delivery.igo.igo_delivery.api.menu.service.MenuService;
+import com.delivery.igo.igo_delivery.common.annotation.Auth;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/stores/{storesId}/menus")
+@RequiredArgsConstructor
 public class MenuController {
+
+    private final MenuService menuService;
+
+    @PostMapping
+    public ResponseEntity<MenuResponseDto> createMenu(@Auth AuthUser authUser, @PathVariable Long storesId,
+                                                      @Valid @RequestBody MenuRequestDto requestDto) {
+
+        menuService.createMenu(authUser, storesId, requestDto);
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/dto/Dto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/dto/Dto.java
@@ -1,4 +1,0 @@
-package com.delivery.igo.igo_delivery.api.menu.dto;
-
-public class Dto {
-}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/dto/request/MenuRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/dto/request/MenuRequestDto.java
@@ -1,0 +1,16 @@
+package com.delivery.igo.igo_delivery.api.menu.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MenuRequestDto {
+
+    @NotBlank(message = "{menu.menuName.notblank}")
+    private final String menuName;
+
+    @NotBlank(message = "{menu.price.notblank}")
+    private final Long price;
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/dto/response/MenuResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/dto/response/MenuResponseDto.java
@@ -1,0 +1,17 @@
+package com.delivery.igo.igo_delivery.api.menu.dto.response;
+
+import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MenuResponseDto {
+
+    private final Long id;
+
+    public static MenuResponseDto of(Menus menus) {
+
+        return new MenuResponseDto(menus.getId());
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/entity/Menus.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/entity/Menus.java
@@ -1,5 +1,6 @@
 package com.delivery.igo.igo_delivery.api.menu.entity;
 
+import com.delivery.igo.igo_delivery.api.menu.dto.request.MenuRequestDto;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;
 import com.delivery.igo.igo_delivery.common.entity.BaseEntity;
 import jakarta.annotation.Nullable;
@@ -45,5 +46,14 @@ public class Menus extends BaseEntity {
 
     public void delete() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public static Menus of(Stores stores, MenuRequestDto requestDto) {
+
+        return Menus.builder()
+                .stores(stores)
+                .menuName(requestDto.getMenuName())
+                .price(requestDto.getPrice())
+                .build();
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/repository/MenuRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/repository/MenuRepository.java
@@ -1,4 +1,7 @@
 package com.delivery.igo.igo_delivery.api.menu.repository;
 
-public interface MenuRepository {
+import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menus, Long> {
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuService.java
@@ -1,4 +1,10 @@
 package com.delivery.igo.igo_delivery.api.menu.service;
 
+import com.delivery.igo.igo_delivery.api.menu.dto.request.MenuRequestDto;
+import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuResponseDto;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+
 public interface MenuService {
+
+    MenuResponseDto createMenu(AuthUser authUser, Long storesId, MenuRequestDto requestDto);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImpl.java
@@ -1,0 +1,55 @@
+package com.delivery.igo.igo_delivery.api.menu.service;
+
+import com.delivery.igo.igo_delivery.api.menu.dto.request.MenuRequestDto;
+import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuResponseDto;
+import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import com.delivery.igo.igo_delivery.api.menu.repository.MenuRepository;
+import com.delivery.igo.igo_delivery.api.store.entity.Stores;
+import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.AuthException;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MenuServiceImpl implements MenuService {
+
+    private final MenuRepository menuRepository;
+
+    private final UserRepository userRepository;
+
+    private final StoreRepository storeRepository;
+
+    @Override
+    @Transactional
+    public MenuResponseDto createMenu(AuthUser authUser, Long storesId, MenuRequestDto requestDto) {
+
+        Users user = userRepository.findById(authUser.getId())
+                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getUserRole() != UserRole.OWNER) {
+
+            throw new GlobalException(ErrorCode.ROLE_OWNER_FORBIDDEN);
+        }
+
+        Stores store = storeRepository.findById(storesId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.STORE_NOT_FOUND));
+
+        if (!Objects.equals(user.getId(), store.getUsers().getId())) {
+            throw new GlobalException(ErrorCode.STORE_OWNER_MISMATCH);
+        }
+
+        Menus menu = Menus.of(store, requestDto);
+        Menus savedMenu = menuRepository.save(menu);
+
+        return MenuResponseDto.of(savedMenu);
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/repository/StoreRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/repository/StoreRepository.java
@@ -1,4 +1,7 @@
 package com.delivery.igo.igo_delivery.api.store.repository;
 
-public interface StoreRepository {
+import com.delivery.igo.igo_delivery.api.store.entity.Stores;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Stores, Long> {
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
@@ -49,7 +49,7 @@ public enum ErrorCode {
     // CartItem
     CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다."),
 
-    // Menu
+    // Store
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다."),
     STORE_OWNER_MISMATCH(HttpStatus.FORBIDDEN, "해당 가게의 사장님만 접근할 수 있습니다.");
 

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
@@ -47,7 +47,11 @@ public enum ErrorCode {
     ROLE_OWNER_FORBIDDEN(HttpStatus.UNAUTHORIZED, "매장 사장님이 아닙니다."),
 
     // CartItem
-    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다.");
+    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다."),
+
+    // Menu
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다."),
+    STORE_OWNER_MISMATCH(HttpStatus.FORBIDDEN, "해당 가게의 사장님만 접근할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -13,3 +13,7 @@ auth.nickname.notblank=닉네임을 입력해 주세요.
 auth.nickname.duplicate=이미 사용 중인 닉네임입니다.
 auth.phoneNumber.notblank=전화번호를 입력해 주세요.
 auth.address.notblank=주소를 입력해 주세요.
+
+## Menu
+menu.menuName.notblank=메뉴 이름을 입력해 주세요.
+menu.price.notblank=메뉴 가격을 입력해 주세요.

--- a/src/test/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImplTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImplTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class MenuServiceImplTest {
+  
+}

--- a/src/test/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImplTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImplTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.delivery.igo.igo_delivery.api.menu.dto.request.MenuRequestDto;
 import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuResponseDto;
@@ -78,6 +80,10 @@ class MenuServiceImplTest {
         MenuResponseDto responseDto = menuService.createMenu(authUser, storeId, requestDto);
 
         assertNotNull(responseDto);
+
+        verify(userRepository).findById(authUser.getId());
+        verify(storeRepository).findById(storeId);
+        verify(menuRepository).save(any(Menus.class));
     }
 
     @Test
@@ -104,6 +110,10 @@ class MenuServiceImplTest {
         });
 
         assertEquals("해당 가게의 사장님만 접근할 수 있습니다.", exception.getMessage());
+
+        verify(userRepository).findById(otherAuthUser.getId());
+        verify(storeRepository).findById(storeId);
+        verify(menuRepository, never()).save(any(Menus.class));
     }
 
     @Test
@@ -129,5 +139,8 @@ class MenuServiceImplTest {
         });
 
         assertEquals("매장 사장님이 아닙니다.", exception.getMessage());
+
+        verify(userRepository).findById(otherAuthUser.getId());
+        verify(storeRepository, never()).findById(storeId);
     }
 }

--- a/src/test/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImplTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImplTest.java
@@ -1,4 +1,133 @@
-import static org.junit.jupiter.api.Assertions.*;
+package com.delivery.igo.igo_delivery.api.menu.service;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.delivery.igo.igo_delivery.api.menu.dto.request.MenuRequestDto;
+import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuResponseDto;
+import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import com.delivery.igo.igo_delivery.api.menu.repository.MenuRepository;
+import com.delivery.igo.igo_delivery.api.store.entity.Stores;
+import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 class MenuServiceImplTest {
-  
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @InjectMocks
+    private MenuServiceImpl menuService;
+
+    private AuthUser authUser;
+
+    private Users user;
+
+    private Stores store;
+
+    @BeforeEach
+    void setUp() {
+        authUser = new AuthUser(1L, "test@gmail.com", "nickname", UserRole.OWNER);
+
+        user = Users.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .nickname("nickname")
+                .userRole(UserRole.OWNER)
+                .build();
+
+        store = Stores.builder()
+                .id(1L)
+                .users(user)
+                .storeName("가게")
+                .build();
+    }
+
+    @Test
+    void menus_메뉴_생성에_성공한다() {
+
+        MenuRequestDto requestDto = new MenuRequestDto("메뉴 이름", 1000L);
+        Menus menu = Menus.of(store, requestDto);
+        Long storeId = 1L;
+
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(menuRepository.save(any())).willReturn(menu);
+
+        MenuResponseDto responseDto = menuService.createMenu(authUser, storeId, requestDto);
+
+        assertNotNull(responseDto);
+    }
+
+    @Test
+    void menus_해당_매장_주인이_아닌_경우_메뉴_생성에_실패한다() {
+
+        AuthUser otherAuthUser = new AuthUser(2L, "test@gmail.com", "nickname", UserRole.OWNER);
+
+        Users otherUser = Users.builder()
+                .id(2L)
+                .email("test@gmail.com")
+                .nickname("nickname")
+                .userRole(UserRole.OWNER)
+                .build();
+
+        MenuRequestDto requestDto = new MenuRequestDto("메뉴 이름", 1000L);
+        Menus menu = Menus.of(store, requestDto);
+        Long storeId = 1L;
+
+        given(userRepository.findById(otherAuthUser.getId())).willReturn(Optional.of(otherUser));
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+        GlobalException exception = assertThrows(GlobalException.class, () -> {
+            menuService.createMenu(otherAuthUser, storeId, requestDto);
+        });
+
+        assertEquals("해당 가게의 사장님만 접근할 수 있습니다.", exception.getMessage());
+    }
+
+    @Test
+    void menus_해당_회원이_매장_주인이_아닌_경우_메뉴_생성에_실패한다() {
+
+        AuthUser otherAuthUser = new AuthUser(2L, "test@gmail.com", "nickname", UserRole.CONSUMER);
+
+        Users otherUser = Users.builder()
+                .id(2L)
+                .email("test@gmail.com")
+                .nickname("nickname")
+                .userRole(UserRole.CONSUMER)
+                .build();
+
+        MenuRequestDto requestDto = new MenuRequestDto("메뉴 이름", 1000L);
+        Menus menu = Menus.of(store, requestDto);
+        Long storeId = 1L;
+
+        given(userRepository.findById(otherAuthUser.getId())).willReturn(Optional.of(otherUser));
+
+        GlobalException exception = assertThrows(GlobalException.class, () -> {
+            menuService.createMenu(otherAuthUser, storeId, requestDto);
+        });
+
+        assertEquals("매장 사장님이 아닙니다.", exception.getMessage());
+    }
 }


### PR DESCRIPTION
## Description
- 메뉴 생성 API 개발
  - 메뉴 생성 시 해당 매장의 주인만 작성할 수 있도록 로직 구현
  - 다음과 같은 경우 예외 처리
    - 존재하지 않는 매장
    - 로그인한 회원이 매장 사장이 아닌 경우
    - 매장 사장이지만 해당 매장의 사장이 아닌 경우
  
- 메뉴 생성에 대한 테스트 코드 작성
## Changes
- `MenuRequestDto`, `MenuResponseDto` 추가
- `MenuController`, `MenuService`에 메뉴 생성 관련 로직 작성
- `messages.properties`에 메뉴와 관련된 메시지 추가
- `ErrorCode`에 메뉴와 관련된 에러코드 추가
- `StoreRepositoy` 수정
  - `JpaRepositoy` 추가
## Screenshots
- 현재 매장 생성 관련 API가 아직 없어 테스트 코드로 기능 확인
<img width="280" alt="스크린샷 2025-04-24 오후 2 33 27" src="https://github.com/user-attachments/assets/a97d3909-61c3-49ab-8639-3c91de9d45ac" />
