### PR TITLE
[Auth] 로그아웃 API 개발 및 인증관련 테스트 단위 테스트 추가

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/controller/AuthController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/controller/AuthController.java
@@ -38,9 +38,8 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<LoginResponseDto> logout(@Auth AuthUser authUser) {
+    public ResponseEntity<Void> logout(@Auth AuthUser authUser) {
         authService.logout(authUser);
         return new ResponseEntity<>(HttpStatus.OK);
-
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/controller/AuthController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.response.LoginResponseDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.response.SignupResponseDto;
 import com.delivery.igo.igo_delivery.api.auth.service.AuthService;
+import com.delivery.igo.igo_delivery.common.annotation.Auth;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -29,9 +31,16 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public  ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto) {
+    public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto) {
         LoginResponseDto loginResponseDto = authService.login(requestDto);
 
         return new ResponseEntity<>(loginResponseDto, HttpStatus.OK);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<LoginResponseDto> logout(@Auth AuthUser authUser) {
+        authService.logout(authUser);
+        return new ResponseEntity<>(HttpStatus.OK);
+
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthService.java
@@ -4,9 +4,12 @@ import com.delivery.igo.igo_delivery.api.auth.dto.request.LoginRequestDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.response.LoginResponseDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.response.SignupResponseDto;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 
 public interface AuthService {
     SignupResponseDto signup(SignupRequestDto signupRequest);
 
     LoginResponseDto login(LoginRequestDto loginRequest);
+
+    void logout(AuthUser authUser);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
@@ -8,6 +8,7 @@ import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
 import com.delivery.igo.igo_delivery.common.config.PasswordEncoder;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.exception.AuthException;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.util.JwtUtil;
@@ -53,5 +54,16 @@ public class AuthServiceImpl implements AuthService {
 
         String bearerToken = jwtUtil.createToken(user);
         return new LoginResponseDto(bearerToken);
+    }
+
+    @Override
+    @Transactional
+    public void logout(AuthUser authUser) {
+        Users user = userRepository.findByEmail(authUser.getEmail())
+                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.getId().equals(authUser.getId())) {
+            throw new AuthException(ErrorCode.FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/repository/UserRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/repository/UserRepository.java
@@ -13,4 +13,5 @@ public interface UserRepository extends JpaRepository<Users, Long> {
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
 
+    Optional<Users> findByEmail(String email);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/validation/PasswordValidator.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/validation/PasswordValidator.java
@@ -6,6 +6,9 @@ import jakarta.validation.ConstraintValidatorContext;
 
 public class PasswordValidator implements ConstraintValidator<Password, String> {
 
+    /**
+     * 영어(대,소문자), 숫자, 특수문자로만 이루어진 8 ~ 15 길이만 비밀번호 검증 통과
+     */
     private static final String REGEX = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,15}$";
 
     @Override

--- a/src/test/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImplUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImplUnitTest.java
@@ -1,0 +1,157 @@
+package com.delivery.igo.igo_delivery.api.auth.service;
+
+import com.delivery.igo.igo_delivery.api.auth.dto.request.LoginRequestDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.response.LoginResponseDto;
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.config.PasswordEncoder;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.AuthException;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.util.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceImplUnitTest {
+
+    public static final SignupRequestDto SIGNUP_REQUEST_DTO = new SignupRequestDto(
+            "email@naver.com",
+            "닉네임",
+            "qwer1234!@#$",
+            "010-1111-2222",
+            "주소",
+            "consumer");
+
+    public static final LoginRequestDto LOGIN_REQUEST_DTO = new LoginRequestDto(
+            "email@naver.com",
+            "qwer1234!@#$");
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @Mock
+    JwtUtil jwtUtil;
+
+    @InjectMocks
+    AuthServiceImpl authService;
+
+    @Test
+    void 회원가입시_이메일_중복_발생시_예외발생_에러코드_USER_EXIST_EMAIL() {
+        // given
+        given(userRepository.existsByEmail(SIGNUP_REQUEST_DTO.getEmail())).willReturn(true);
+
+        // when & then
+        AuthException authException = assertThrows(AuthException.class, () -> authService.signup(SIGNUP_REQUEST_DTO));
+        assertEquals(ErrorCode.USER_EXIST_EMAIL, authException.getErrorCode());
+        verify(userRepository).existsByEmail(SIGNUP_REQUEST_DTO.getEmail());
+    }
+
+    @Test
+    void 회원가입시_닉네임_중복_발생시_예외발생_에러코드_USER_EXIST_NICKNAME() {
+        // given
+        given(userRepository.existsByNickname(SIGNUP_REQUEST_DTO.getNickname())).willReturn(true);
+
+        // when & then
+        AuthException authException = assertThrows(AuthException.class, () -> authService.signup(SIGNUP_REQUEST_DTO));
+        assertEquals(ErrorCode.USER_EXIST_NICKNAME, authException.getErrorCode());
+        verify(userRepository).existsByNickname(SIGNUP_REQUEST_DTO.getNickname());
+    }
+
+    @Test
+    void 로그인이_성공하면_토큰이_발급됨() {
+        // given
+        Users mockUser = Users.of(SIGNUP_REQUEST_DTO, "encodedPassword");
+        given(userRepository.findByEmailAndUserStatus(SIGNUP_REQUEST_DTO.getEmail(), UserStatus.LIVE)).willReturn(Optional.of(mockUser));
+        given(passwordEncoder.matches(LOGIN_REQUEST_DTO.getPassword(), mockUser.getPassword())).willReturn(true);
+        given(jwtUtil.createToken(mockUser)).willReturn("mockToken");
+
+        // when
+        LoginResponseDto loginResponseDto = authService.login(LOGIN_REQUEST_DTO);
+
+        // then
+        assertEquals("mockToken", loginResponseDto.getBearerToken());
+        verify(userRepository).findByEmailAndUserStatus(SIGNUP_REQUEST_DTO.getEmail(), UserStatus.LIVE);
+        verify(passwordEncoder).matches(LOGIN_REQUEST_DTO.getPassword(), mockUser.getPassword());
+        verify(jwtUtil).createToken(mockUser);
+    }
+
+    @Test
+    void 로그인시_유저가_존재하지않으면_예외발생_예러코드_USER_NOT_FOUND() {  // 비활성화된 유저도 조회가 안되기 때문에 함께 검증됨
+        // given
+        given(userRepository.findByEmailAndUserStatus(LOGIN_REQUEST_DTO.getEmail(), UserStatus.LIVE)).willReturn(Optional.empty());
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class, () -> authService.login(LOGIN_REQUEST_DTO));
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        verify(userRepository).findByEmailAndUserStatus(LOGIN_REQUEST_DTO.getEmail(), UserStatus.LIVE);
+    }
+
+    @Test
+    void 로그인시_비밀번호가_일지하지않으면_예외발생_에러코드_LOGIN_FALIED() {
+        // given
+        Users mockUser = Users.of(SIGNUP_REQUEST_DTO, "encodedPassword");
+
+        given(userRepository.findByEmailAndUserStatus(LOGIN_REQUEST_DTO.getEmail(), UserStatus.LIVE)).willReturn(Optional.of(mockUser));
+        given(passwordEncoder.matches(LOGIN_REQUEST_DTO.getPassword(), mockUser.getPassword())).willReturn(false);
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class, () -> authService.login(LOGIN_REQUEST_DTO));
+        assertEquals(ErrorCode.LOGIN_FAILED, exception.getErrorCode());
+        verify(userRepository).findByEmailAndUserStatus(LOGIN_REQUEST_DTO.getEmail(), UserStatus.LIVE);
+        verify(passwordEncoder).matches(LOGIN_REQUEST_DTO.getPassword(), mockUser.getPassword());
+    }
+
+    @Test
+    void 비회원이_로그아웃을_시도하면_예외발생_에러코드_USER_NOT_FOUND() {
+        // given
+        AuthUser nonUser = new AuthUser(999L, "없는회원임", "없는회원임", null);
+
+        given(userRepository.findByEmail(nonUser.getEmail())).willReturn(Optional.empty());
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class, () -> authService.logout(nonUser));
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        verify(userRepository).findByEmail(nonUser.getEmail());
+    }
+
+    @Test
+    void 로그인_사용자가아닌_다른회원이_로그아웃을_시도하면_예외발생_에러코드_FORBIDDEN() {
+        // given
+        Users mockUser = Users.builder()
+                .id(1L)
+                .email("email@naver.com")
+                .nickname("닉네임")
+                .password("encodedPassword")
+                .phoneNumber("010-1111-2222")
+                .address("서울시 강남구")
+                .userRole(UserRole.CONSUMER)
+                .userStatus(UserStatus.LIVE)
+                .build();
+
+        AuthUser fakeUser = new AuthUser(999L, mockUser.getEmail(), mockUser.getNickname(), mockUser.getUserRole());
+
+        given(userRepository.findByEmail(fakeUser.getEmail())).willReturn(Optional.of(mockUser));
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class, () -> authService.logout(fakeUser));
+        assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
+        verify(userRepository).findByEmail(fakeUser.getEmail());
+    }
+}

--- a/src/test/java/com/delivery/igo/igo_delivery/common/config/PasswordEncoderUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/common/config/PasswordEncoderUnitTest.java
@@ -1,0 +1,50 @@
+package com.delivery.igo.igo_delivery.common.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasswordEncoderUnitTest {
+
+    PasswordEncoder encoder = new PasswordEncoder();
+
+    @Test
+    void 비밀번호_인코딩_성공() {
+        // given
+        String rawPassword = "qwer1234!";
+
+        // when
+        String encoded = encoder.encode(rawPassword);
+
+        // then
+        assertNotEquals(rawPassword, encoded);
+        assertTrue(encoder.matches(rawPassword, encoded));
+    }
+
+    @Test
+    void 동일한_비밀번호는_매칭_성공() {
+        // given
+        String rawPassword = "qwer1234!";
+        String inputPassword = "qwer1234!";
+
+        // when
+        String encoded = encoder.encode(rawPassword);
+
+        // then
+        assertTrue(encoder.matches(inputPassword, encoded));
+    }
+
+    @Test
+    void 다른_비밀번호는_매칭_실패() {
+        // given
+        String rawPassword = "qwer1234!";
+        String wrongPassword = "wrong1234!";
+
+        // when
+        String encoded = encoder.encode(rawPassword);
+
+        // then
+        assertFalse(encoder.matches(wrongPassword, encoded));
+    }
+
+}

--- a/src/test/java/com/delivery/igo/igo_delivery/common/validation/EmailDuplicatedValidatorUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/common/validation/EmailDuplicatedValidatorUnitTest.java
@@ -1,0 +1,42 @@
+package com.delivery.igo.igo_delivery.common.validation;
+
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class EmailDuplicatedValidatorUnitTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    EmailDuplicatedValidator validator;
+
+    @Test
+    void 중복된_이메일이_아니면_성공() {
+        // given
+        String email = "test@email.com";
+        given(userRepository.existsByEmail(email)).willReturn(false);
+
+        // when & then
+        assertTrue(validator.isValid(email, null));
+    }
+
+    @Test
+    void 중복된_이메일이면_실패() {
+        // given
+        String email = "test@email.com";
+        given(userRepository.existsByEmail(email)).willReturn(true);
+
+        // when & then
+        assertFalse(validator.isValid(email, null));
+    }
+}

--- a/src/test/java/com/delivery/igo/igo_delivery/common/validation/NicknameDuplicatedValidatorUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/common/validation/NicknameDuplicatedValidatorUnitTest.java
@@ -1,0 +1,41 @@
+package com.delivery.igo.igo_delivery.common.validation;
+
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class NicknameDuplicatedValidatorUnitTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    NicknameDuplicatedValidator validator;
+
+    @Test
+    void 중복된_닉네임이_아니면_성공() {
+        // given
+        String nickname = "내가닉네임이다";
+        given(userRepository.existsByNickname(nickname)).willReturn(false);
+
+        // when & then
+        assertTrue(validator.isValid(nickname, null));
+    }
+
+    @Test
+    void 중복된_닉네임이면_실패() {
+        // given
+        String nickname = "내가닉네임이다";
+        given(userRepository.existsByNickname(nickname)).willReturn(true);
+
+        // when & then
+        assertFalse(validator.isValid(nickname, null));
+    }
+}

--- a/src/test/java/com/delivery/igo/igo_delivery/common/validation/PasswordValidatorUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/common/validation/PasswordValidatorUnitTest.java
@@ -1,0 +1,59 @@
+package com.delivery.igo.igo_delivery.common.validation;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PasswordValidatorUnitTest {
+
+    PasswordValidator validator = new PasswordValidator();
+
+
+    @Test
+    void 길이가_8자이고_조건에맞으면_성공() {
+        assertTrue(validator.isValid("qwer1234!", null));
+    }
+
+    @Test
+    void 길이가_15자이고_조건에맞으면_성공() {
+        assertTrue(validator.isValid("qwert12345!@#$%", null));
+    }
+
+    @Test
+    void 특수문자가_없으면_실패() {
+        assertFalse(validator.isValid("qwert123456", null));
+    }
+
+    @Test
+    void 숫자가_없으면_실패() {
+        assertFalse(validator.isValid("qwert!@#$", null));
+    }
+
+    @Test
+    void 숫자만_포함된_비밀번호는_실패() {
+        assertFalse(validator.isValid("12345678", null));
+    }
+
+    @Test
+    void 영문만_포함된_비밀번호는_실패() {
+        assertFalse(validator.isValid("abcdefg", null));
+    }
+
+    @Test
+    void 한글이나_공백이_포함되면_실패() {
+        assertFalse(validator.isValid("ㅂㅈㄷㄱ12 34!@#$", null));
+    }
+
+    @Test
+    void 조건에_맞지만_길이가_16자이상이면_실패() {
+        assertFalse(validator.isValid("qwert12345!@#$%!", null));
+    }
+
+    @Test
+    void 조건에_맞지만_길이가_7자이하이면_실패() {
+        assertFalse(validator.isValid("qw12!@#", null));
+    }
+
+}


### PR DESCRIPTION
## Description
1. 로그아웃 API 개발
    - 로그아웃 시 비회원인 경우 예외 발생
    - 로그아웃 시 로그인한 회원이 아닌 경우 예외 발생
    - 서버에서는 예외 검증만하고 ok응답 후 클라이언트에서 토큰을 삭제하는 로직으로 구성(무상태이기 때문에 서버에서 보관중인 토큰이 없음)

2. 직접만든 Validator 코드들 단위 테스트
    - 비밀번호 길이, 패턴 유효성 검증 테스트
    - 이메일 중복, 닉네임 중복 검증 테스트

3. PasswordEncoder 단위 테스트
    - 비밀번호 암호화, 매칭 검증 테스트

4. AuthServiceImpl 메서드들 단위 테스트
    - 회원가입시 발생되는 예외 케이스 검증 테스트
    - 로그인 성공시 토큰 발급 검증 테스트
    - 로그인시 발생되는 예외 케이스 검증 테스트
    - 로그아웃시 발생되는 예외 케이스 검증 테스트

5. 비밀번호 암호화 정규식에 주석 추가

## Changes
1. AuthController, AuthServiceImpl logout() 메서드 추가

2. Test 코드들 추가
    - PasswordValidatorUnitTest
    - AuthServiceImplUnitTest
    - NicknameDuplicatedValidatorUnitTest
    - EmailDuplicatedValidatorUnitTest
