### PR TITLE
[Users] 내 정보 조회 API 개발 및 단위 테스트

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/controller/AuthController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/controller/AuthController.java
@@ -38,7 +38,7 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<LoginResponseDto> logout(@Auth AuthUser authUser) {
+    public ResponseEntity<Void> logout(@Auth AuthUser authUser) {
         authService.logout(authUser);
         return new ResponseEntity<>(HttpStatus.OK);
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/controller/AuthController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.response.LoginResponseDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.response.SignupResponseDto;
 import com.delivery.igo.igo_delivery.api.auth.service.AuthService;
+import com.delivery.igo.igo_delivery.common.annotation.Auth;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -29,9 +31,16 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public  ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto) {
+    public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto) {
         LoginResponseDto loginResponseDto = authService.login(requestDto);
 
         return new ResponseEntity<>(loginResponseDto, HttpStatus.OK);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<LoginResponseDto> logout(@Auth AuthUser authUser) {
+        authService.logout(authUser);
+        return new ResponseEntity<>(HttpStatus.OK);
+
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthService.java
@@ -4,9 +4,12 @@ import com.delivery.igo.igo_delivery.api.auth.dto.request.LoginRequestDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.response.LoginResponseDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.response.SignupResponseDto;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 
 public interface AuthService {
     SignupResponseDto signup(SignupRequestDto signupRequest);
 
     LoginResponseDto login(LoginRequestDto loginRequest);
+
+    void logout(AuthUser authUser);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
@@ -8,6 +8,7 @@ import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
 import com.delivery.igo.igo_delivery.common.config.PasswordEncoder;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.exception.AuthException;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.util.JwtUtil;
@@ -53,5 +54,16 @@ public class AuthServiceImpl implements AuthService {
 
         String bearerToken = jwtUtil.createToken(user);
         return new LoginResponseDto(bearerToken);
+    }
+
+    @Override
+    @Transactional
+    public void logout(AuthUser authUser) {
+        Users user = userRepository.findByEmail(authUser.getEmail())
+                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.getId().equals(authUser.getId())) {
+            throw new AuthException(ErrorCode.FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/controller/UserController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/controller/UserController.java
@@ -1,4 +1,35 @@
 package com.delivery.igo.igo_delivery.api.user.controller;
 
+import com.delivery.igo.igo_delivery.api.user.dto.resonse.FindUserResponseDto;
+import com.delivery.igo.igo_delivery.api.user.service.UserService;
+import com.delivery.igo.igo_delivery.common.annotation.Auth;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * 회원 조회가 아닌 내 정보 조회이므로 getMyInfo()로 메서드 명을 작성함
+     *
+     * @param id 조회할 유저의 id
+     * @param authUser 인증된 사용자 정보
+     * @return 조회된 유저의 응답 DTO, 성공시 OK응답
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<FindUserResponseDto> getMyInfo(@PathVariable Long id, @Auth AuthUser authUser) {
+        FindUserResponseDto responseDto = userService.findUserById(id, authUser);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/Dto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/Dto.java
@@ -1,4 +1,0 @@
-package com.delivery.igo.igo_delivery.api.user.dto;
-
-public class Dto {
-}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/request/requestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/request/requestDto.java
@@ -1,0 +1,5 @@
+package com.delivery.igo.igo_delivery.api.user.dto.request;
+
+public class requestDto {
+    // todo 나중에 사용
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/resonse/FindUserResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/resonse/FindUserResponseDto.java
@@ -1,0 +1,36 @@
+package com.delivery.igo.igo_delivery.api.user.dto.resonse;
+
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class FindUserResponseDto {
+
+    private final Long id;
+    private final String email;
+    private final String nickname;
+    private final String phoneNumber;
+    private final String address;
+    private final String role;
+    private final LocalDateTime createAt;
+    private final LocalDateTime modifiedAt;
+
+    public static FindUserResponseDto from(Users findUser) {
+        return new FindUserResponseDto(
+                findUser.getId(),
+                findUser.getEmail(),
+                findUser.getNickname(),
+                findUser.getPhoneNumber(),
+                findUser.getAddress(),
+                findUser.getUserRole().toString(),
+                findUser.getCreatedAt(),
+                findUser.getModifiedAt()
+        );
+    }
+
+
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
@@ -1,7 +1,10 @@
 package com.delivery.igo.igo_delivery.api.user.entity;
 
 import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.entity.BaseEntity;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @NoArgsConstructor
@@ -49,8 +53,24 @@ public class Users extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus userStatus;
 
+    // 삭제
     public void delete() {
-        this.deletedAt = LocalDateTime.now();
+        deletedAt = LocalDateTime.now();
+        userStatus = UserStatus.INACTIVE;
+    }
+
+    // 삭제 검증, 삭제 되었다면 예외 발생
+    public void validateDelete() {
+        if (userStatus == UserStatus.INACTIVE) {
+            throw new GlobalException(ErrorCode.DELETED_USER);
+        }
+    }
+
+    // 접근 권한 검증, 로그인한 유저의 id와 id가 다르면 예외 발생
+    public void validateAccess(AuthUser authUser) {
+        if (!Objects.equals(authUser.getId(), id)) {
+            throw new GlobalException(ErrorCode.FORBIDDEN);
+        }
     }
 
     public static Users of(SignupRequestDto signupRequestDto, String encodedPassword) {

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
@@ -73,6 +73,20 @@ public class Users extends BaseEntity {
         }
     }
 
+    // 사업자 계정인지 검증
+    public void validateOwner() {
+        if (userRole != UserRole.OWNER) {
+            throw new GlobalException(ErrorCode.ROLE_OWNER_FORBIDDEN);
+        }
+    }
+
+    // 일반 고객인지 검증
+    public void validateConsumer() {
+        if (userRole != UserRole.CONSUMER) {
+            throw new GlobalException(ErrorCode.ROLE_CONSUMER_FORBIDDEN);
+        }
+    }
+
     public static Users of(SignupRequestDto signupRequestDto, String encodedPassword) {
         UserRole userRole = UserRole.of(signupRequestDto.getUserRole());
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/repository/UserRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/repository/UserRepository.java
@@ -13,4 +13,5 @@ public interface UserRepository extends JpaRepository<Users, Long> {
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
 
+    Optional<Users> findByEmail(String email);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserService.java
@@ -1,4 +1,8 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
+import com.delivery.igo.igo_delivery.api.user.dto.resonse.FindUserResponseDto;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+
 public interface UserService {
+    FindUserResponseDto findUserById(Long id, AuthUser authUser);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -1,0 +1,29 @@
+package com.delivery.igo.igo_delivery.api.user.service;
+
+import com.delivery.igo.igo_delivery.api.user.dto.resonse.FindUserResponseDto;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public FindUserResponseDto findUserById(Long id, AuthUser authUser) {
+        Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+        
+        users.validateAccess(authUser); // 로그인한 본인인지 검증
+        users.validateDelete(); // 삭제 검증, 삭제된 상태라면 404 예외 발생
+
+        return FindUserResponseDto.from(users);
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
@@ -37,9 +37,8 @@ public enum ErrorCode {
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
 
     // User
-    DUPLICATED_USERNAME(HttpStatus.BAD_REQUEST, "사용자 이름이 중복되었습니다. 다른 이름으로 가입해 주세요."),
-    DUPLICATED_USER(HttpStatus.BAD_REQUEST, "사용자 이름이나 email이 이미 등록되어있습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    DELETED_USER(HttpStatus.NOT_FOUND, "삭제된 사용자 입니다."),
     USER_NOT_FOUND_ROLE(HttpStatus.NOT_FOUND, "권한 정보가 없습니다."),
     INVALID_USER_ROLE(HttpStatus.FORBIDDEN, "유효하지 않은 사용자 권한입니다."),
     ROLE_ADMIN_FORBIDDEN(HttpStatus.UNAUTHORIZED, "관리자 권한이 없습니다."),

--- a/src/main/java/com/delivery/igo/igo_delivery/common/validation/PasswordValidator.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/validation/PasswordValidator.java
@@ -6,6 +6,9 @@ import jakarta.validation.ConstraintValidatorContext;
 
 public class PasswordValidator implements ConstraintValidator<Password, String> {
 
+    /**
+     * 영어(대,소문자), 숫자, 특수문자로만 이루어진 8 ~ 15 길이만 비밀번호 검증 통과
+     */
     private static final String REGEX = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,15}$";
 
     @Override

--- a/src/test/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImplUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImplUnitTest.java
@@ -1,0 +1,157 @@
+package com.delivery.igo.igo_delivery.api.auth.service;
+
+import com.delivery.igo.igo_delivery.api.auth.dto.request.LoginRequestDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
+import com.delivery.igo.igo_delivery.api.auth.dto.response.LoginResponseDto;
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.config.PasswordEncoder;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.AuthException;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.util.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceImplUnitTest {
+
+    public static final SignupRequestDto SIGNUP_REQUEST_DTO = new SignupRequestDto(
+            "email@naver.com",
+            "닉네임",
+            "qwer1234!@#$",
+            "010-1111-2222",
+            "주소",
+            "consumer");
+
+    public static final LoginRequestDto LOGIN_REQUEST_DTO = new LoginRequestDto(
+            "email@naver.com",
+            "qwer1234!@#$");
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @Mock
+    JwtUtil jwtUtil;
+
+    @InjectMocks
+    AuthServiceImpl authService;
+
+    @Test
+    void 회원가입시_이메일_중복_발생시_예외발생_에러코드_USER_EXIST_EMAIL() {
+        // given
+        given(userRepository.existsByEmail(SIGNUP_REQUEST_DTO.getEmail())).willReturn(true);
+
+        // when & then
+        AuthException authException = assertThrows(AuthException.class, () -> authService.signup(SIGNUP_REQUEST_DTO));
+        assertEquals(ErrorCode.USER_EXIST_EMAIL, authException.getErrorCode());
+        verify(userRepository).existsByEmail(SIGNUP_REQUEST_DTO.getEmail());
+    }
+
+    @Test
+    void 회원가입시_닉네임_중복_발생시_예외발생_에러코드_USER_EXIST_NICKNAME() {
+        // given
+        given(userRepository.existsByNickname(SIGNUP_REQUEST_DTO.getNickname())).willReturn(true);
+
+        // when & then
+        AuthException authException = assertThrows(AuthException.class, () -> authService.signup(SIGNUP_REQUEST_DTO));
+        assertEquals(ErrorCode.USER_EXIST_NICKNAME, authException.getErrorCode());
+        verify(userRepository).existsByNickname(SIGNUP_REQUEST_DTO.getNickname());
+    }
+
+    @Test
+    void 로그인이_성공하면_토큰이_발급됨() {
+        // given
+        Users mockUser = Users.of(SIGNUP_REQUEST_DTO, "encodedPassword");
+        given(userRepository.findByEmailAndUserStatus(SIGNUP_REQUEST_DTO.getEmail(), UserStatus.LIVE)).willReturn(Optional.of(mockUser));
+        given(passwordEncoder.matches(LOGIN_REQUEST_DTO.getPassword(), mockUser.getPassword())).willReturn(true);
+        given(jwtUtil.createToken(mockUser)).willReturn("mockToken");
+
+        // when
+        LoginResponseDto loginResponseDto = authService.login(LOGIN_REQUEST_DTO);
+
+        // then
+        assertEquals("mockToken", loginResponseDto.getBearerToken());
+        verify(userRepository).findByEmailAndUserStatus(SIGNUP_REQUEST_DTO.getEmail(), UserStatus.LIVE);
+        verify(passwordEncoder).matches(LOGIN_REQUEST_DTO.getPassword(), mockUser.getPassword());
+        verify(jwtUtil).createToken(mockUser);
+    }
+
+    @Test
+    void 로그인시_유저가_존재하지않으면_예외발생_예러코드_USER_NOT_FOUND() {  // 비활성화된 유저도 조회가 안되기 때문에 함께 검증됨
+        // given
+        given(userRepository.findByEmailAndUserStatus(LOGIN_REQUEST_DTO.getEmail(), UserStatus.LIVE)).willReturn(Optional.empty());
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class, () -> authService.login(LOGIN_REQUEST_DTO));
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        verify(userRepository).findByEmailAndUserStatus(LOGIN_REQUEST_DTO.getEmail(), UserStatus.LIVE);
+    }
+
+    @Test
+    void 로그인시_비밀번호가_일지하지않으면_예외발생_에러코드_LOGIN_FALIED() {
+        // given
+        Users mockUser = Users.of(SIGNUP_REQUEST_DTO, "encodedPassword");
+
+        given(userRepository.findByEmailAndUserStatus(LOGIN_REQUEST_DTO.getEmail(), UserStatus.LIVE)).willReturn(Optional.of(mockUser));
+        given(passwordEncoder.matches(LOGIN_REQUEST_DTO.getPassword(), mockUser.getPassword())).willReturn(false);
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class, () -> authService.login(LOGIN_REQUEST_DTO));
+        assertEquals(ErrorCode.LOGIN_FAILED, exception.getErrorCode());
+        verify(userRepository).findByEmailAndUserStatus(LOGIN_REQUEST_DTO.getEmail(), UserStatus.LIVE);
+        verify(passwordEncoder).matches(LOGIN_REQUEST_DTO.getPassword(), mockUser.getPassword());
+    }
+
+    @Test
+    void 비회원이_로그아웃을_시도하면_예외발생_에러코드_USER_NOT_FOUND() {
+        // given
+        AuthUser nonUser = new AuthUser(999L, "없는회원임", "없는회원임", null);
+
+        given(userRepository.findByEmail(nonUser.getEmail())).willReturn(Optional.empty());
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class, () -> authService.logout(nonUser));
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        verify(userRepository).findByEmail(nonUser.getEmail());
+    }
+
+    @Test
+    void 로그인_사용자가아닌_다른회원이_로그아웃을_시도하면_예외발생_에러코드_FORBIDDEN() {
+        // given
+        Users mockUser = Users.builder()
+                .id(1L)
+                .email("email@naver.com")
+                .nickname("닉네임")
+                .password("encodedPassword")
+                .phoneNumber("010-1111-2222")
+                .address("서울시 강남구")
+                .userRole(UserRole.CONSUMER)
+                .userStatus(UserStatus.LIVE)
+                .build();
+
+        AuthUser fakeUser = new AuthUser(999L, mockUser.getEmail(), mockUser.getNickname(), mockUser.getUserRole());
+
+        given(userRepository.findByEmail(fakeUser.getEmail())).willReturn(Optional.of(mockUser));
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class, () -> authService.logout(fakeUser));
+        assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
+        verify(userRepository).findByEmail(fakeUser.getEmail());
+    }
+}

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/entity/UsersUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/entity/UsersUnitTest.java
@@ -1,0 +1,33 @@
+package com.delivery.igo.igo_delivery.api.user.entity;
+
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UsersUnitTest {
+
+    @Test
+    void 회원삭제_검증시_회원의_상태가_INACTIVE이면_예외_발생_에러코드_DELETED_USER() {
+        // given
+        Users user = Users.builder().userStatus(UserStatus.INACTIVE).build();
+
+        // when & then
+        GlobalException exception = assertThrows(GlobalException.class, () -> user.validateDelete());
+        assertEquals(ErrorCode.DELETED_USER, exception.getErrorCode());
+    }
+
+    @Test
+    void 접근권한_검증시_필드id와_매개변수의_id가_다르면_예외_빨생_에러코드_FORBIDDEN() {
+        // given
+        Users user = Users.builder().id(1L).build();
+        AuthUser authUser = new AuthUser(2L, null, null, null);
+
+        // when * then
+        GlobalException exception = assertThrows(GlobalException.class, () -> user.validateAccess(authUser));
+        assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
+    }
+}

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplUnitTest.java
@@ -1,0 +1,71 @@
+package com.delivery.igo.igo_delivery.api.user.service;
+
+import com.delivery.igo.igo_delivery.api.user.dto.resonse.FindUserResponseDto;
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplUnitTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    UserServiceImpl userService;
+
+    @Test
+    void 내정보가_정상적으로_조회됨() {
+        // given
+        Users user = Users.builder()
+                .id(1L)
+                .email("email@naver.com")
+                .nickname("정상유저")
+                .phoneNumber("010-1111-2222")
+                .address("세상에없는구")
+                .userRole(UserRole.OWNER)
+                .userStatus(UserStatus.LIVE)
+                .build();
+
+        AuthUser authUser = new AuthUser(1L, "email@naver.com", "정상유저", UserRole.OWNER);
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
+
+        // when
+        FindUserResponseDto findUserDto = userService.findUserById(1L, authUser);
+
+        // then
+        assertEquals(user.getId(), findUserDto.getId());
+        assertEquals(user.getEmail(), findUserDto.getEmail());
+        assertEquals(user.getNickname(), findUserDto.getNickname());
+        verify(userRepository).findById(authUser.getId());
+    }
+
+    @Test
+    void 내정보가_없으면_예외_발생_에러코드_USER_NOT_FOUND() {
+        // given
+        AuthUser authUser = new AuthUser(1L, "email@naver.com", "로그인유저", UserRole.OWNER);
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.empty());
+
+        // when & then
+        GlobalException exception = assertThrows(GlobalException.class, () -> userService.findUserById(1L, authUser));
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        verify(userRepository).findById(authUser.getId());
+
+    }
+}
+

--- a/src/test/java/com/delivery/igo/igo_delivery/common/config/PasswordEncoderUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/common/config/PasswordEncoderUnitTest.java
@@ -1,0 +1,50 @@
+package com.delivery.igo.igo_delivery.common.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasswordEncoderUnitTest {
+
+    PasswordEncoder encoder = new PasswordEncoder();
+
+    @Test
+    void 비밀번호_인코딩_성공() {
+        // given
+        String rawPassword = "qwer1234!";
+
+        // when
+        String encoded = encoder.encode(rawPassword);
+
+        // then
+        assertNotEquals(rawPassword, encoded);
+        assertTrue(encoder.matches(rawPassword, encoded));
+    }
+
+    @Test
+    void 동일한_비밀번호는_매칭_성공() {
+        // given
+        String rawPassword = "qwer1234!";
+        String inputPassword = "qwer1234!";
+
+        // when
+        String encoded = encoder.encode(rawPassword);
+
+        // then
+        assertTrue(encoder.matches(inputPassword, encoded));
+    }
+
+    @Test
+    void 다른_비밀번호는_매칭_실패() {
+        // given
+        String rawPassword = "qwer1234!";
+        String wrongPassword = "wrong1234!";
+
+        // when
+        String encoded = encoder.encode(rawPassword);
+
+        // then
+        assertFalse(encoder.matches(wrongPassword, encoded));
+    }
+
+}

--- a/src/test/java/com/delivery/igo/igo_delivery/common/validation/EmailDuplicatedValidatorUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/common/validation/EmailDuplicatedValidatorUnitTest.java
@@ -1,0 +1,42 @@
+package com.delivery.igo.igo_delivery.common.validation;
+
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class EmailDuplicatedValidatorUnitTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    EmailDuplicatedValidator validator;
+
+    @Test
+    void 중복된_이메일이_아니면_성공() {
+        // given
+        String email = "test@email.com";
+        given(userRepository.existsByEmail(email)).willReturn(false);
+
+        // when & then
+        assertTrue(validator.isValid(email, null));
+    }
+
+    @Test
+    void 중복된_이메일이면_실패() {
+        // given
+        String email = "test@email.com";
+        given(userRepository.existsByEmail(email)).willReturn(true);
+
+        // when & then
+        assertFalse(validator.isValid(email, null));
+    }
+}

--- a/src/test/java/com/delivery/igo/igo_delivery/common/validation/NicknameDuplicatedValidatorUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/common/validation/NicknameDuplicatedValidatorUnitTest.java
@@ -1,0 +1,41 @@
+package com.delivery.igo.igo_delivery.common.validation;
+
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class NicknameDuplicatedValidatorUnitTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    NicknameDuplicatedValidator validator;
+
+    @Test
+    void 중복된_닉네임이_아니면_성공() {
+        // given
+        String nickname = "내가닉네임이다";
+        given(userRepository.existsByNickname(nickname)).willReturn(false);
+
+        // when & then
+        assertTrue(validator.isValid(nickname, null));
+    }
+
+    @Test
+    void 중복된_닉네임이면_실패() {
+        // given
+        String nickname = "내가닉네임이다";
+        given(userRepository.existsByNickname(nickname)).willReturn(true);
+
+        // when & then
+        assertFalse(validator.isValid(nickname, null));
+    }
+}

--- a/src/test/java/com/delivery/igo/igo_delivery/common/validation/PasswordValidatorUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/common/validation/PasswordValidatorUnitTest.java
@@ -1,0 +1,59 @@
+package com.delivery.igo.igo_delivery.common.validation;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PasswordValidatorUnitTest {
+
+    PasswordValidator validator = new PasswordValidator();
+
+
+    @Test
+    void 길이가_8자이고_조건에맞으면_성공() {
+        assertTrue(validator.isValid("qwer1234!", null));
+    }
+
+    @Test
+    void 길이가_15자이고_조건에맞으면_성공() {
+        assertTrue(validator.isValid("qwert12345!@#$%", null));
+    }
+
+    @Test
+    void 특수문자가_없으면_실패() {
+        assertFalse(validator.isValid("qwert123456", null));
+    }
+
+    @Test
+    void 숫자가_없으면_실패() {
+        assertFalse(validator.isValid("qwert!@#$", null));
+    }
+
+    @Test
+    void 숫자만_포함된_비밀번호는_실패() {
+        assertFalse(validator.isValid("12345678", null));
+    }
+
+    @Test
+    void 영문만_포함된_비밀번호는_실패() {
+        assertFalse(validator.isValid("abcdefg", null));
+    }
+
+    @Test
+    void 한글이나_공백이_포함되면_실패() {
+        assertFalse(validator.isValid("ㅂㅈㄷㄱ12 34!@#$", null));
+    }
+
+    @Test
+    void 조건에_맞지만_길이가_16자이상이면_실패() {
+        assertFalse(validator.isValid("qwert12345!@#$%!", null));
+    }
+
+    @Test
+    void 조건에_맞지만_길이가_7자이하이면_실패() {
+        assertFalse(validator.isValid("qw12!@#", null));
+    }
+
+}


### PR DESCRIPTION
## Description
1. 내 정보 조회 API 개발
    - 내 정보 조회시 DB에 데이터 없으면 404 예외 발생
    - 로그인한 유저와 API 호출한 유저가 다르면 403 예외 발생
    - 이미 삭제된 상태라면 404 예외 발생
    - 유저 Entity에 사업자 계정 검증, 읿반 고객 검증, 로그인 본인 확인 검증, 삭제 계정 검증 메서드 추가
    - **삭제된 유저 검증과, 로그인한 본인인지 검증하는 코드는 여러곳에서 재사용할 것을 예상하여 Entity에서 제공하므로 해당 PR이 Merge가 되면 DDD 차원에서 다른 도메인에서도 해당 메서드를 통해 검증하도록 변경하시기를 권장합니다**

2. 단위 테스트
    - UsersEntity 검증 메서드 단위 테스트
    - UserServiceImp 메서드 단위 테스트

3. 추가 refactoring
    - Users에 존재하는 delete() 메서드 호출 시 상태도 INACTIVE로 변경되도록 수정
    - 모든 API가 개발이 되면 이 삭제 상태값은 모두 공용으로 사용하도록 리펙토링이 필요함(굳이 각 도메인마다 가질 필요가 없음)

## Changes
- Users, UserController, UserServiceImpl
- UsersUnitTest, UserServiceImplUnitTest


## Screenshots
1. 회원 조회 성공
<img width="1085" alt="image" src="https://github.com/user-attachments/assets/0c4b520b-10ac-4e74-b82d-1593c4a7b958" />

2. 없는 회원 조회ㅈ시 예외 응답
<img width="674" alt="image" src="https://github.com/user-attachments/assets/b0c2f5e9-24df-4744-b700-a914ae7c0166" />


3. 테스트 통과 스샷
![image](https://github.com/user-attachments/assets/7069da1b-ed78-4afc-b5c3-34d853d30564)
