### PR TITLE
[Store] 매장 생성 기능 구현

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
@@ -4,6 +4,11 @@ import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
 import com.delivery.igo.igo_delivery.api.store.service.StoreService;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.annotation.Auth;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,14 +24,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class StoreController {
 
     private final StoreService storeService;
+    private final UserRepository userRepository;
 
     // 매장 생성
     @PostMapping
     public ResponseEntity<StoreResponseDto> createStore(
-            @Valid @RequestBody StoreRequestDto requestDto,
-            @AuthenticationPrincipal Users loginUser
+            @Auth AuthUser loginUser,
+            @Valid @RequestBody StoreRequestDto requestDto
     ) {
-        StoreResponseDto response = storeService.createStore(requestDto, loginUser);
+        Users user = userRepository.findById(loginUser.getId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        StoreResponseDto response = storeService.createStore(requestDto, user);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
@@ -4,6 +4,7 @@ import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
 import com.delivery.igo.igo_delivery.api.store.service.StoreService;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +22,10 @@ public class StoreController {
 
     // 매장 생성
     @PostMapping
-    public ResponseEntity<StoreResponseDto> createStore(@RequestBody StoreRequestDto requestDto, @AuthenticationPrincipal Users loginUser) {
+    public ResponseEntity<StoreResponseDto> createStore(
+            @Valid @RequestBody StoreRequestDto requestDto,
+            @AuthenticationPrincipal Users loginUser
+    ) {
         StoreResponseDto response = storeService.createStore(requestDto, loginUser);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
@@ -1,4 +1,28 @@
 package com.delivery.igo.igo_delivery.api.store.controller;
 
+import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
+import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
+import com.delivery.igo.igo_delivery.api.store.service.StoreService;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stores")
 public class StoreController {
+
+    private final StoreService storeService;
+
+    // 매장 생성
+    @PostMapping
+    public ResponseEntity<StoreResponseDto> createStore(@RequestBody StoreRequestDto requestDto, @AuthenticationPrincipal Users loginUser) {
+        StoreResponseDto response = storeService.createStore(requestDto, loginUser);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/converter/StoreConverter.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/converter/StoreConverter.java
@@ -13,7 +13,6 @@ public class StoreConverter {
     // 매장 생성 요청 DTO를 엔티티로 변환
     public static Stores toEntity(StoreRequestDto dto, Users owner) {
         return Stores.builder()
-                .users(owner)
                 .storeName(dto.getStoreName())
                 .storeAddress(dto.getStoreAddress())
                 .storePhoneNumber(dto.getStorePhoneNumber())
@@ -21,6 +20,9 @@ public class StoreConverter {
                 .endTime(Time.valueOf(dto.getEndTime()))
                 .minOrderPrice(dto.getMinOrderPrice())
                 .storeStatus(StoreStatus.LIVE)
+                .users(owner)
+                .reviewCount(0)
+                .avgRating(0.0)
                 .build();
     }
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/converter/StoreConverter.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/converter/StoreConverter.java
@@ -1,0 +1,42 @@
+package com.delivery.igo.igo_delivery.api.store.converter;
+
+import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
+import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
+import com.delivery.igo.igo_delivery.api.store.entity.Stores;
+import com.delivery.igo.igo_delivery.api.store.entity.StoreStatus;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+
+import java.sql.Time;
+
+public class StoreConverter {
+
+    // 매장 생성 요청 DTO를 엔티티로 변환
+    public static Stores toEntity(StoreRequestDto dto, Users owner) {
+        return Stores.builder()
+                .users(owner)
+                .storeName(dto.getStoreName())
+                .storeAddress(dto.getStoreAddress())
+                .storePhoneNumber(dto.getStorePhoneNumber())
+                .openTime(Time.valueOf(dto.getOpenTime()))
+                .endTime(Time.valueOf(dto.getEndTime()))
+                .minOrderPrice(dto.getMinOrderPrice())
+                .storeStatus(StoreStatus.LIVE)
+                .build();
+    }
+
+    // 매장 엔티티를 응답용 DTO로 변환
+    public static StoreResponseDto toDto(Stores store) {
+        return StoreResponseDto.builder()
+                .id(store.getId())
+                .storeName(store.getStoreName())
+                .storeAddress(store.getStoreAddress())
+                .storePhoneNumber(store.getStorePhoneNumber())
+                .openTime(store.getOpenTime().toLocalTime())
+                .endTime(store.getEndTime().toLocalTime())
+                .minOrderPrice(store.getMinOrderPrice())
+                .storeStatus(store.getStoreStatus().name())
+                .createdAt(store.getCreatedAt())
+                .modifiedAt(store.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/Dto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/Dto.java
@@ -1,4 +1,0 @@
-package com.delivery.igo.igo_delivery.api.store.dto;
-
-public class Dto {
-}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreRequestDto.java
@@ -14,22 +14,22 @@ import java.time.LocalTime;
 @AllArgsConstructor
 public class StoreRequestDto {
 
-    @NotBlank(message = "매장 이름은 필수입니다.")
+    @NotBlank(message = "{store.storeName.notblank}")
     private String storeName;           // 매장명
 
-    @NotBlank(message = "매장 주소는 필수입니다.")
+    @NotBlank(message = "{store.storeAddress.notblank}")
     private String storeAddress;        // 매장 주소
 
-    @NotBlank(message = "매장 전화번호는 필수입니다.")
+    @NotBlank(message = "{store.storePhoneNumber.notblank}")
     private String storePhoneNumber;    // 매장 전화번호
 
-    @NotNull(message = "오픈 시간은 필수입니다.")
+    @NotNull(message = "{store.openTime.notnull}")
     private LocalTime openTime;         // 오픈 시간
 
-    @NotNull(message = "마감 시간은 필수입니다.")
+    @NotNull(message = "{store.endTime.notnull}")
     private LocalTime endTime;          // 마감 시간
 
-    @NotNull(message = "최소 주문 금액은 필수입니다.")
-    @Min(value = 10000, message = "최소 주문 금액은 10000원 이상이어야 합니다.")
+    @NotNull(message = "{store.minOrderPrice.notnull}")
+    @Min(value = 1000, message = "{store.minOrderPrice.min}")
     private Integer minOrderPrice;      // 최소 주문 금액
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreRequestDto.java
@@ -1,0 +1,19 @@
+package com.delivery.igo.igo_delivery.api.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreRequestDto {
+    private String storeName;           // 매장명
+    private String storeAddress;        // 매장 주소
+    private String storePhoneNumber;    // 매장 전화번호
+    private LocalTime openTime;         // 오픈 시간
+    private LocalTime endTime;          // 마감 시간
+    private Integer minOrderPrice;      // 최소 주문 금액
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreRequestDto.java
@@ -1,5 +1,8 @@
 package com.delivery.igo.igo_delivery.api.store.dto;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +13,23 @@ import java.time.LocalTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StoreRequestDto {
+
+    @NotBlank(message = "매장 이름은 필수입니다.")
     private String storeName;           // 매장명
+
+    @NotBlank(message = "매장 주소는 필수입니다.")
     private String storeAddress;        // 매장 주소
+
+    @NotBlank(message = "매장 전화번호는 필수입니다.")
     private String storePhoneNumber;    // 매장 전화번호
+
+    @NotNull(message = "오픈 시간은 필수입니다.")
     private LocalTime openTime;         // 오픈 시간
+
+    @NotNull(message = "마감 시간은 필수입니다.")
     private LocalTime endTime;          // 마감 시간
+
+    @NotNull(message = "최소 주문 금액은 필수입니다.")
+    @Min(value = 10000, message = "최소 주문 금액은 10000원 이상이어야 합니다.")
     private Integer minOrderPrice;      // 최소 주문 금액
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreResponseDto.java
@@ -1,5 +1,6 @@
 package com.delivery.igo.igo_delivery.api.store.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,15 +9,16 @@ import java.time.LocalTime;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class StoreResponseDto {
-    private Long id;
-    private String storeName;
-    private String storeAddress;
-    private String storePhoneNumber;
-    private LocalTime openTime;
-    private LocalTime endTime;
-    private Integer minOrderPrice;
-    private String storeStatus;
-    private LocalDateTime createdAt;
-    private LocalDateTime modifiedAt;
+    private Long id;                    // 매장 ID
+    private String storeName;           // 매장 이름
+    private String storeAddress;        // 매장 주소
+    private String storePhoneNumber;    // 매장 전화번호
+    private LocalTime openTime;         // 영업 시작 시간
+    private LocalTime endTime;          // 영업 종료 시간
+    private Integer minOrderPrice;      // 최소 주문 금액
+    private String storeStatus;         // 매장 상태 (LIVE, CLOSED 등)
+    private LocalDateTime createdAt;    // 생성 시각
+    private LocalDateTime modifiedAt;   // 수정 시각
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreResponseDto.java
@@ -1,0 +1,22 @@
+package com.delivery.igo.igo_delivery.api.store.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class StoreResponseDto {
+    private Long id;
+    private String storeName;
+    private String storeAddress;
+    private String storePhoneNumber;
+    private LocalTime openTime;
+    private LocalTime endTime;
+    private Integer minOrderPrice;
+    private String storeStatus;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/entity/StoreStatus.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/entity/StoreStatus.java
@@ -1,5 +1,6 @@
 package com.delivery.igo.igo_delivery.api.store.entity;
 
 public enum StoreStatus {
-    LIVE
+    LIVE,
+    CLOSED
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/entity/Stores.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/entity/Stores.java
@@ -11,8 +11,6 @@ import lombok.NoArgsConstructor;
 import java.sql.Time;
 import java.time.LocalDateTime;
 
-import static javax.swing.text.html.HTML.Attribute.N;
-
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/entity/Stores.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/entity/Stores.java
@@ -54,10 +54,10 @@ public class Stores extends BaseEntity {
     private StoreStatus storeStatus;
 
     @Column(nullable = false)
-    private Integer reviewCount = 0;
+    private Integer reviewCount = 0; // 리뷰 수 (초기값 0)
 
     @Column(nullable = false)
-    private Double avgRating = 0.0;
+    private Double avgRating = 0.0; // 평균 별점 (초기값 0.0)
 
     public void delete() {
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/entity/Stores.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/entity/Stores.java
@@ -1,6 +1,5 @@
 package com.delivery.igo.igo_delivery.api.store.entity;
 
-import com.delivery.igo.igo_delivery.api.order.entity.Orders;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.common.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -11,6 +10,8 @@ import lombok.NoArgsConstructor;
 
 import java.sql.Time;
 import java.time.LocalDateTime;
+
+import static javax.swing.text.html.HTML.Attribute.N;
 
 @Entity
 @NoArgsConstructor
@@ -29,13 +30,13 @@ public class Stores extends BaseEntity {
     @JoinColumn(name = "users_id", nullable = false)
     private Users users;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 30)
     private String storeName;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 100)
     private String storeAddress;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
     private String storePhoneNumber;
 
     @Column(nullable = false)
@@ -54,7 +55,11 @@ public class Stores extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private StoreStatus storeStatus;
 
-    // ToDo 리뷰수 별점 평균 - 동시성 제어 시 작성하기
+    @Column(nullable = false)
+    private Integer reviewCount = 0;
+
+    @Column(nullable = false)
+    private Double avgRating = 0.0;
 
     public void delete() {
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/repository/StoreRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/repository/StoreRepository.java
@@ -4,11 +4,6 @@ import com.delivery.igo.igo_delivery.api.store.entity.StoreStatus;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
-import com.delivery.igo.igo_delivery.api.store.entity.Stores;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface StoreRepository extends JpaRepository<Stores, Long> {
-}
 
 public interface StoreRepository extends JpaRepository<Stores, Long> {
     long countByUsersAndStoreStatusIsNot(Users user, StoreStatus status);

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/repository/StoreRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/repository/StoreRepository.java
@@ -1,4 +1,9 @@
 package com.delivery.igo.igo_delivery.api.store.repository;
 
-public interface StoreRepository {
+import com.delivery.igo.igo_delivery.api.store.entity.Stores;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Stores, Long> {
+    long countByUsersAndStoreStatusIsNot(Users user, com.delivery.igo.igo_delivery.api.store.entity.StoreStatus status);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/repository/StoreRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/repository/StoreRepository.java
@@ -1,9 +1,10 @@
 package com.delivery.igo.igo_delivery.api.store.repository;
 
+import com.delivery.igo.igo_delivery.api.store.entity.StoreStatus;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Stores, Long> {
-    long countByUsersAndStoreStatusIsNot(Users user, com.delivery.igo.igo_delivery.api.store.entity.StoreStatus status);
+    long countByUsersAndStoreStatusIsNot(Users user, StoreStatus status);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreService.java
@@ -1,4 +1,9 @@
 package com.delivery.igo.igo_delivery.api.store.service;
 
+import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
+import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+
 public interface StoreService {
+    StoreResponseDto createStore(StoreRequestDto requestDto, Users owner);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -6,6 +6,8 @@ import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;
 import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +23,11 @@ public class StoreServiceImpl implements StoreService{
     @Override
     @Transactional
     public StoreResponseDto createStore(StoreRequestDto requestDto, Users owner) {
+
+        // 사장님 권한이 아닌 경우 예외 발생
+        if (!owner.getUserRole().equals(UserRole.OWNER)) {
+            throw new GlobalException(ErrorCode.NOT_OWNER);
+        }
 
         // 사장이 이미 3개의 매장을 등록한 경우 예외 발생
         long count = storeRepository.countByUsersAndStoreStatusIsNot(owner, com.delivery.igo.igo_delivery.api.store.entity.StoreStatus.CLOSED);

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -5,6 +5,7 @@ import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;
 import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.exception.GlobalException;

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -1,0 +1,37 @@
+package com.delivery.igo.igo_delivery.api.store.service;
+
+import com.delivery.igo.igo_delivery.api.store.converter.StoreConverter;
+import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
+import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
+import com.delivery.igo.igo_delivery.api.store.entity.Stores;
+import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StoreServiceImpl implements StoreService{
+
+    // 매장 저장 및 조회를 위한 Repository
+    private final StoreRepository storeRepository;
+
+    // 매장 생성
+    @Override
+    @Transactional
+    public StoreResponseDto createStore(StoreRequestDto requestDto, Users owner) {
+
+        // 사장이 이미 3개의 매장을 등록한 경우 예외 발생
+        long count = storeRepository.countByUsersAndStoreStatusIsNot(owner, com.delivery.igo.igo_delivery.api.store.entity.StoreStatus.CLOSED);
+        if (count >= 3) {
+            throw new IllegalStateException("매장은 최대 3개까지 운영할 수 있습니다.");
+        }
+
+        // DTO -> 엔티티 변환 후 저장
+        Stores store = storeRepository.save(StoreConverter.toEntity(requestDto, owner));
+
+        // 저장된 엔티티를 DTO로 변환하여 반환
+        return StoreConverter.toDto(store);
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
@@ -30,6 +30,9 @@ public enum ErrorCode {
     DUPLICATED_USER(HttpStatus.BAD_REQUEST, "사용자 이름이나 email이 이미 등록되어있습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 
+    // Store
+    NOT_OWNER(HttpStatus.FORBIDDEN, "사장님 권한이 아닙니다."),
+
     // CartItem
     CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다.");
 

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalException.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalException.java
@@ -12,4 +12,8 @@ public class GlobalException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
+    public GlobalException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalExceptionHandler.java
@@ -47,7 +47,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler
     public ResponseEntity<ErrorDto> authFailedException(AuthException e, HttpServletRequest request) {
-        log.error("[authFiledException] ex: ", e);
+        log.error("[authFailedException] ex: ", e);
         ErrorCode errorCode = e.getErrorCode();
 
         ErrorDto errorDto = new ErrorDto(

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -17,3 +17,12 @@ auth.address.notblank=주소를 입력해 주세요.
 ## Menu
 menu.menuName.notblank=메뉴 이름을 입력해 주세요.
 menu.price.notblank=메뉴 가격을 입력해 주세요.
+
+# Store
+store.storeName.notblank=매장 이름을 입력해 주세요.
+store.storeAddress.notblank=매장 주소를 입력해 주세요.
+store.storePhoneNumber.notblank=매장 전화번호를 입력해 주세요.
+store.openTime.notnull=오픈 시간을 입력해 주세요.
+store.endTime.notnull=마감 시간을 입력해 주세요.
+store.minOrderPrice.notnull=최소 주문 금액을 입력해 주세요.
+store.minOrderPrice.min=최소 주문 금액은 10000원 이상이어야 합니다.

--- a/src/test/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceTest.java
@@ -1,0 +1,71 @@
+package com.delivery.igo.igo_delivery.api.store.service;
+
+import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
+import com.delivery.igo.igo_delivery.api.store.entity.StoreStatus;
+import com.delivery.igo.igo_delivery.api.store.entity.Stores;
+import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.Time;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class StoreServiceTest {
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @InjectMocks
+    private StoreServiceImpl storeService;
+
+    @Test
+    void 매장_정상_생성() {
+
+        // given
+        Users owner = new Users();
+        StoreRequestDto request = new StoreRequestDto(
+                "초코라떼가제일좋아",
+                "인천시 미추홀구",
+                "010-8282-8282",
+                LocalTime.of(8, 0),
+                LocalTime.of(22, 0),
+                10000
+        );
+
+        // 이미 등록된 매장이 2개라고 가정
+        when(storeRepository.countByUsersAndStoreStatusIsNot(owner, StoreStatus.CLOSED))
+                .thenReturn(2L);
+
+        // storeRepository.save() 호출 시, 실제 매장 엔티티 리턴하도록 설정
+        Stores store = Stores.builder()
+                .users(owner)
+                .storeName("초코라떼가제일좋아")
+                .storeAddress("인천시 미추홀구")
+                .storePhoneNumber("010-8282-8282")
+                .openTime(Time.valueOf(request.getOpenTime()))
+                .endTime(Time.valueOf(request.getEndTime()))
+                .minOrderPrice(request.getMinOrderPrice())
+                .storeStatus(StoreStatus.LIVE)
+                .build();
+
+        when(storeRepository.save(any(Stores.class))).thenReturn(store);
+
+        // when
+        var response = storeService.createStore(request, owner);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getStoreName()).isEqualTo("매장");
+        verify(storeRepository).save(any(Stores.class));
+    }
+}


### PR DESCRIPTION
### Description
- 사장님만 매장을 등록할 수 있도록 권한 검사를 적용했습니다.  
- 매장은 최대 3개까지만 생성 가능하도록 제한을 두었습니다.  
- 요청 값 유효성 검증 및 예외 처리 로직을 적용했고, Postman을 통해 정상 동작을 확인했습니다.

---

### Changes
- 매장 생성 API (`POST /api/stores`) 구현  
- `StoreRequestDto`, `StoreResponseDto` 작성 및 주석 추가  
- `StoreConverter`를 통한 엔티티-DTO 변환 구현  
- `GlobalException`과 `ErrorCode`를 활용한 예외 처리  
- `message.properties`에 매장 관련 메시지 추가  
- 인증 어노테이션 `@Auth` 기반 흐름 적용

---

### Screenshots

#### ✅ 201 Created - 매장 생성 성공  
![201](https://github.com/user-attachments/assets/3fbc8484-f95a-4ace-8a39-c24f0a20678a)

#### ❌ 400 Bad Request - 필수 입력 누락  
![400](https://github.com/user-attachments/assets/af90acd8-be1c-4255-8014-73f0080037d9)

#### ❌ 401 Unauthorized - 인증되지 않은 사용자  
![401](https://github.com/user-attachments/assets/f84ce832-6e4b-4c96-932e-495982b50576)

#### ❌ 403 Forbidden - 사장님 권한 아님  
![403](https://github.com/user-attachments/assets/d63bf39c-9702-49dd-9a4b-d3829c475c44)
