### PR TITLE
[Cart]: 장바구니 메뉴 추가 기능 구현

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/controller/CartController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/controller/CartController.java
@@ -6,6 +6,7 @@ import com.delivery.igo.igo_delivery.api.cart.dto.CartResponse;
 import com.delivery.igo.igo_delivery.api.cart.service.CartService;
 import com.delivery.igo.igo_delivery.common.annotation.Auth;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +25,7 @@ public class CartController {
     @PostMapping
     public ResponseEntity<CartResponse> addCart(
             @Auth AuthUser authUser,
-            @RequestBody CartRequest request
+            @Valid @RequestBody CartRequest request
             ){
         return ResponseEntity.status(HttpStatus.CREATED).body(cartService.addCart(authUser,request));
     }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/controller/CartController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/controller/CartController.java
@@ -1,4 +1,31 @@
 package com.delivery.igo.igo_delivery.api.cart.controller;
 
+
+import com.delivery.igo.igo_delivery.api.cart.dto.CartRequest;
+import com.delivery.igo.igo_delivery.api.cart.dto.CartResponse;
+import com.delivery.igo.igo_delivery.api.cart.service.CartService;
+import com.delivery.igo.igo_delivery.common.annotation.Auth;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/carts")
+@RequiredArgsConstructor
 public class CartController {
+
+    private final CartService cartService;
+
+    @PostMapping
+    public ResponseEntity<CartResponse> addCart(
+            @Auth AuthUser authUser,
+            @RequestBody CartRequest request
+            ){
+        return ResponseEntity.status(HttpStatus.CREATED).body(cartService.addCart(authUser,request));
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/CartRequest.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/CartRequest.java
@@ -1,5 +1,7 @@
 package com.delivery.igo.igo_delivery.api.cart.dto;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,7 +9,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CartRequest {
 
+    @NotBlank(message = "{menu.id.notblank}")
     private Long menuId;
+
+    @NotBlank(message ="{cart.quantity.notnull}")
+    @Min(value = 1, message = "{cart.quantity.min}")
     private Integer cartQuantity;
 
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/CartRequest.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/CartRequest.java
@@ -1,0 +1,14 @@
+package com.delivery.igo.igo_delivery.api.cart.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CartRequest {
+
+    private Long menuId;
+    private Integer cartQuantity;
+
+
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/CartResponse.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/CartResponse.java
@@ -1,0 +1,19 @@
+package com.delivery.igo.igo_delivery.api.cart.dto;
+
+import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CartResponse {
+
+    private final Long userId;
+    private final Long cartId;
+
+    public static CartResponse of(Carts carts){
+        return new CartResponse(carts.getUsers().getId(), carts.getId());
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/CartResponse.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/CartResponse.java
@@ -13,7 +13,7 @@ public class CartResponse {
     private final Long userId;
     private final Long cartId;
 
-    public static CartResponse of(Carts carts){
+    public static CartResponse from(Carts carts){
         return new CartResponse(carts.getUsers().getId(), carts.getId());
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/entity/CartItems.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/entity/CartItems.java
@@ -1,6 +1,7 @@
 package com.delivery.igo.igo_delivery.api.cart.entity;
 
 import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,4 +35,14 @@ public class CartItems {
     @Column(nullable = false)
     private Integer cartQuantity;
 
+    public CartItems(Menus menus, Carts carts, Long cartPrice, Integer cartQuantity){
+        this.menus = menus;
+        this.carts = carts;
+        this.cartPrice = cartPrice;
+        this.cartQuantity = cartQuantity;
+    }
+
+    public void addQuantity(Integer cartQuantity){
+        this.cartQuantity += cartQuantity;
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/repository/CartItemsRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/repository/CartItemsRepository.java
@@ -1,0 +1,19 @@
+package com.delivery.igo.igo_delivery.api.cart.repository;
+
+import com.delivery.igo.igo_delivery.api.cart.entity.CartItems;
+import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
+import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CartItemsRepository extends JpaRepository<CartItems, Long> {
+
+    List<CartItems> findAllByCarts(Carts carts);
+
+    Optional<CartItems> findByCartsAndMenus(Carts carts, Menus menus);
+
+    //장바구니 초기화
+    void deleteAllByCarts(Carts carts);
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartService.java
@@ -1,0 +1,11 @@
+package com.delivery.igo.igo_delivery.api.cart.service;
+
+import com.delivery.igo.igo_delivery.api.cart.dto.CartRequest;
+import com.delivery.igo.igo_delivery.api.cart.dto.CartResponse;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+
+public interface CartService {
+
+    CartResponse addCart(AuthUser authUser, CartRequest request);
+
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImpl.java
@@ -57,7 +57,7 @@ public class CartServiceImpl implements CartService{
                     .anyMatch(storeId -> !storeId.equals(menus.getStores().getId()));
 
             if (haveOtherStoreItems) {
-                cartItems.ifPresent(item -> cartItemsRepository.deleteAll(List.of(item)));
+                cartItemsRepository.deleteAll(List.of(existingItem));
                 CartItems newItem = new CartItems(menus, carts, menus.getPrice(), request.getCartQuantity());
                 cartItemsRepository.save(newItem);
             }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImpl.java
@@ -1,0 +1,63 @@
+package com.delivery.igo.igo_delivery.api.cart.service;
+
+import com.delivery.igo.igo_delivery.api.cart.dto.CartRequest;
+import com.delivery.igo.igo_delivery.api.cart.dto.CartResponse;
+import com.delivery.igo.igo_delivery.api.cart.entity.CartItems;
+import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
+import com.delivery.igo.igo_delivery.api.cart.repository.CartItemsRepository;
+import com.delivery.igo.igo_delivery.api.cart.repository.CartRepository;
+import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import com.delivery.igo.igo_delivery.api.menu.repository.MenuRepository;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CartServiceImpl implements CartService{
+
+    private final UserRepository userRepository;
+    private final MenuRepository menuRepository;
+    private final CartRepository cartRepository;
+    private final CartItemsRepository cartItemsRepository;
+
+    //todo :  해당 service 관련 에러 코드 추가
+    @Override
+    @Transactional
+    public CartResponse addCart(AuthUser authUser, CartRequest request) {
+
+        //로그인한 유저 호출
+        Users users = userRepository.findById(authUser.getId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        //해당 유저의 장바구니 호출
+        Carts carts = cartRepository.findByUsers(users)
+                .orElseThrow(()-> new GlobalException(ErrorCode.NOT_FOUND));
+
+        //요청 들어온 메뉴 호출 -> 존재하지 않는 메뉴일시 에러 출력
+        Menus menus = menuRepository.findById(request.getMenuId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND));
+
+        // 해당 메뉴가 장바구니에 존재하는지 여부 확인 후 메뉴 및 수량 추가
+        Optional<CartItems> cartItems = cartItemsRepository.findByCartsAndMenus(carts, menus);
+        if (cartItems.isPresent()) {
+            // 해당 메뉴 이미 존재할 경우 입력받은 만큼 수량 추가
+            CartItems existingItem = cartItems.get();
+            existingItem.addQuantity(request.getCartQuantity());
+        } else {
+            // 새로운 메뉴+수량 장바구니에 추가
+            CartItems newItem = new CartItems(menus, carts, menus.getPrice(), request.getCartQuantity());
+            cartItemsRepository.save(newItem);
+        }
+        return CartResponse.of(carts);
+    }
+
+
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImpl.java
@@ -68,7 +68,7 @@ public class CartServiceImpl implements CartService{
             CartItems newItem = new CartItems(menus, carts, menus.getPrice(), request.getCartQuantity());
             cartItemsRepository.save(newItem);
         }
-        return CartResponse.of(carts);
+        return CartResponse.from(carts);
     }
 
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -17,3 +17,8 @@ auth.address.notblank=주소를 입력해 주세요.
 ## Menu
 menu.menuName.notblank=메뉴 이름을 입력해 주세요.
 menu.price.notblank=메뉴 가격을 입력해 주세요.
+menu.id.notblank = 메뉴 ID를 입력해 주세요.
+
+## Cart
+cart.quantity.min=수량은 최소 1개 이상이어야 합니다.
+cart.quantity.notnull=수량을 입력해 주세요.

--- a/src/test/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImplTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImplTest.java
@@ -1,0 +1,140 @@
+package com.delivery.igo.igo_delivery.api.cart.service;
+
+import com.delivery.igo.igo_delivery.api.cart.dto.CartRequest;
+import com.delivery.igo.igo_delivery.api.cart.dto.CartResponse;
+import com.delivery.igo.igo_delivery.api.cart.entity.CartItems;
+import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
+import com.delivery.igo.igo_delivery.api.cart.repository.CartItemsRepository;
+import com.delivery.igo.igo_delivery.api.cart.repository.CartRepository;
+import com.delivery.igo.igo_delivery.api.menu.entity.MenuStatus;
+import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import com.delivery.igo.igo_delivery.api.menu.repository.MenuRepository;
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+
+import java.util.Optional;
+
+
+@ExtendWith(MockitoExtension.class)
+class CartServiceTest {
+
+    @InjectMocks
+    private CartServiceImpl cartService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CartRepository cartRepository;
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    @Mock
+    private CartItemsRepository cartItemsRepository;
+
+    @Test
+    void 장바구니_신규_메뉴_추가() {
+        // given
+        Long usersId = 1L;
+        Long menusId = 1L;
+        int quantity = 2;
+
+        AuthUser authUser = new AuthUser(usersId, "test123@gmail.com", "테스트용", UserRole.CONSUMER);
+        Users users = Users.builder()
+                .id(usersId)
+                .email("test@test.com")
+                .nickname("tester")
+                .build();
+        Carts carts = Carts.builder()
+                .users(users)
+                .build();
+        Menus menus = Menus.builder()
+                .id(menusId)
+                .menuName("피자")
+                .price(10000L)
+                .menuStatus(MenuStatus.LIVE)
+                .build();
+
+        CartRequest request = new CartRequest(menusId, quantity);
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(users));
+        given(cartRepository.findByUsers(users)).willReturn(Optional.of(carts));
+        given(menuRepository.findById(anyLong())).willReturn(Optional.of(menus));
+        given(cartItemsRepository.findByCartsAndMenus(carts, menus)).willReturn(Optional.empty());
+
+        // when
+        CartResponse response = cartService.addCart(authUser, request);
+
+        // then
+        assertNotNull(response);
+        verify(cartItemsRepository).save(any(CartItems.class));
+    }
+
+    @Test
+    void 장바구니_기존_메뉴_수량_증가() {
+        // given
+        Long usersId = 1L;
+        Long menusId = 1L;
+        int originalQuantity = 2;
+        int addQuantity = 4;
+
+        AuthUser authUser = new AuthUser(usersId, "test123@gmail.com", "테스트용", UserRole.CONSUMER);
+
+        Users users = Users.builder()
+                .id(usersId)
+                .email("test@test.com")
+                .nickname("tester")
+                .build();
+
+        Carts carts = Carts.builder()
+                .users(users)
+                .build();
+
+        Menus menus = Menus.builder()
+                .id(menusId)
+                .menuName("피자")
+                .price(10000L)
+                .menuStatus(MenuStatus.LIVE)
+                .build();
+
+        CartItems existingCartItem = CartItems.builder()
+                .menus(menus)
+                .carts(carts)
+                .cartPrice(menus.getPrice())
+                .cartQuantity(originalQuantity)
+                .build();
+
+        CartRequest request = new CartRequest(menusId, addQuantity);
+
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(users));
+        given(cartRepository.findByUsers(users)).willReturn(Optional.of(carts));
+        given(menuRepository.findById(anyLong())).willReturn(Optional.of(menus));
+        given(cartItemsRepository.findByCartsAndMenus(carts, menus)).willReturn(Optional.of(existingCartItem));
+
+
+        // when
+        CartResponse response = cartService.addCart(authUser, request);
+
+        // then
+        assertNotNull(response);
+        assertEquals(originalQuantity + addQuantity, existingCartItem.getCartQuantity());
+
+        verify(cartItemsRepository).findByCartsAndMenus(carts, menus);
+    }
+
+}


### PR DESCRIPTION
## Description
- 로그인한 유저의 장바구니를 호출합니다.
- 회원 가입시 생성된 장바구니의 키 값을 가지고 있는 cart_iems에 메뉴를 저장합니다.
- 다른 매장의 메뉴가 이미 장바구니에 존재하면 기존 장바구니 목록을 삭제합니다.
- 이미 cart_items에 해당 메뉴가 존재하는지 확인 후 수량을 추가합니다.
- 관련 service 에러 코드는 후에 추가 하겠습니다.

## Changes
- 관련 로직을 위한 dto를 생성하고 entity에 메서드를 추가 했습니다.
- 코드의 변경사항을 글로 최대한 전달하여 리뷰어가 코드의 변경 지점을 어느정도 예측하도록 합니다.
## Screenshots
![image](https://github.com/user-attachments/assets/d8577fc8-c25c-45f3-a547-85e4ef00221a)

테스트 코드 실행 사진입니다.