### PR TITLE
[Users] 내 정보 수정 API 개발 및 단위, 통합 테스트 진행

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // 통합 테스트를 위한 h2 DB
+    testImplementation 'com.h2database:h2'
+
     // bcrypt
     implementation 'at.favre.lib:bcrypt:0.10.2'
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/controller/UserController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/controller/UserController.java
@@ -1,16 +1,15 @@
 package com.delivery.igo.igo_delivery.api.user.controller;
 
-import com.delivery.igo.igo_delivery.api.user.dto.resonse.FindUserResponseDto;
+import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
+import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.api.user.service.UserService;
 import com.delivery.igo.igo_delivery.common.annotation.Auth;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
@@ -27,8 +26,18 @@ public class UserController {
      * @return 조회된 유저의 응답 DTO, 성공시 OK응답
      */
     @GetMapping("/{id}")
-    public ResponseEntity<FindUserResponseDto> getMyInfo(@PathVariable Long id, @Auth AuthUser authUser) {
-        FindUserResponseDto responseDto = userService.findUserById(id, authUser);
+    public ResponseEntity<UserResponseDto> getMyInfo(@PathVariable Long id, @Auth AuthUser authUser) {
+        UserResponseDto responseDto = userService.findUserById(id, authUser);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<UserResponseDto> modifyMyInfo(@PathVariable Long id,
+                                                        @Auth AuthUser authUser,
+                                                        @Valid @RequestBody UpdateUserRequestDto requestDto) {
+
+        UserResponseDto responseDto = userService.updateUserById(id, authUser, requestDto);
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/request/UpdateUserRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/request/UpdateUserRequestDto.java
@@ -1,0 +1,28 @@
+package com.delivery.igo.igo_delivery.api.user.dto.request;
+
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 수정 요청 값이기 때문에 클라이언트에서 null이 오지못하도록 기본 메시지를 출력
+ */
+@Getter
+@AllArgsConstructor
+public class UpdateUserRequestDto {
+
+    @NotBlank
+    private final String nickname;
+
+    @NotBlank
+    private final String phoneNumber;
+
+    @NotBlank
+    private final String address;
+
+    @NotNull
+    private final UserRole role;
+
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/request/requestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/request/requestDto.java
@@ -1,5 +1,0 @@
-package com.delivery.igo.igo_delivery.api.user.dto.request;
-
-public class requestDto {
-    // todo 나중에 사용
-}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/resonse/UserResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/resonse/UserResponseDto.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
-public class FindUserResponseDto {
+public class UserResponseDto {
 
     private final Long id;
     private final String email;
@@ -19,8 +19,8 @@ public class FindUserResponseDto {
     private final LocalDateTime createAt;
     private final LocalDateTime modifiedAt;
 
-    public static FindUserResponseDto from(Users findUser) {
-        return new FindUserResponseDto(
+    public static UserResponseDto from(Users findUser) {
+        return new UserResponseDto(
                 findUser.getId(),
                 findUser.getEmail(),
                 findUser.getNickname(),

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
@@ -1,6 +1,7 @@
 package com.delivery.igo.igo_delivery.api.user.entity;
 
 import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
+import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.entity.BaseEntity;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
@@ -52,6 +53,21 @@ public class Users extends BaseEntity {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private UserStatus userStatus;
+
+    public void updateBy(UpdateUserRequestDto requestDto) {
+        if (requestDto.getNickname() != null) {
+            this.nickname = requestDto.getNickname();
+        }
+        if (requestDto.getPhoneNumber() != null) {
+            this.phoneNumber = requestDto.getPhoneNumber();
+        }
+        if (requestDto.getAddress() != null) {
+            this.address = requestDto.getAddress();
+        }
+        if (requestDto.getRole() != null) {
+            this.userRole = requestDto.getRole();
+        }
+    }
 
     // 삭제
     public void delete() {

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserService.java
@@ -1,8 +1,11 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
+import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 
 public interface UserService {
     UserResponseDto findUserById(Long id, AuthUser authUser);
+
+    UserResponseDto updateUserById(Long id, AuthUser authUser, UpdateUserRequestDto requestDto);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserService.java
@@ -1,8 +1,8 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
-import com.delivery.igo.igo_delivery.api.user.dto.resonse.FindUserResponseDto;
+import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 
 public interface UserService {
-    FindUserResponseDto findUserById(Long id, AuthUser authUser);
+    UserResponseDto findUserById(Long id, AuthUser authUser);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -1,6 +1,6 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
-import com.delivery.igo.igo_delivery.api.user.dto.resonse.FindUserResponseDto;
+import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
@@ -9,8 +9,6 @@ import com.delivery.igo.igo_delivery.common.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Objects;
-
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
@@ -18,12 +16,12 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
 
     @Override
-    public FindUserResponseDto findUserById(Long id, AuthUser authUser) {
+    public UserResponseDto findUserById(Long id, AuthUser authUser) {
         Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
         
         users.validateAccess(authUser); // 로그인한 본인인지 검증
         users.validateDelete(); // 삭제 검증, 삭제된 상태라면 404 예외 발생
 
-        return FindUserResponseDto.from(users);
+        return UserResponseDto.from(users);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -1,9 +1,11 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
+import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.AuthException;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,23 @@ public class UserServiceImpl implements UserService {
         
         users.validateAccess(authUser); // 로그인한 본인인지 검증
         users.validateDelete(); // 삭제 검증, 삭제된 상태라면 404 예외 발생
+
+        return UserResponseDto.from(users);
+    }
+
+    @Override
+    public UserResponseDto updateUserById(Long id, AuthUser authUser, UpdateUserRequestDto requestDto) {
+        Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        // 닉네임 변경 시 변경할 닉네임이 DB에 있으면 예외 발생
+        if (!users.getNickname().equals(requestDto.getNickname()) &&
+                userRepository.existsByNickname(requestDto.getNickname())) {
+            throw new AuthException(ErrorCode.USER_EXIST_NICKNAME);
+        }
+
+        users.validateAccess(authUser); // 로그인한 보인인지 검증
+        users.validateDelete();         // 삭제 검증
+        users.updateBy(requestDto);     // 업데이트
 
         return UserResponseDto.from(users);
     }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -32,6 +32,8 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public UserResponseDto updateUserById(Long id, AuthUser authUser, UpdateUserRequestDto requestDto) {
         Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+        users.validateAccess(authUser); // 로그인한 본인인지 검증
+        users.validateDelete();         // 삭제 검증
 
         // 닉네임 변경 시 변경할 닉네임이 DB에 있으면 예외 발생
         if (!users.getNickname().equals(requestDto.getNickname()) &&
@@ -39,8 +41,7 @@ public class UserServiceImpl implements UserService {
             throw new GlobalException(ErrorCode.USER_EXIST_NICKNAME);
         }
 
-        users.validateAccess(authUser); // 로그인한 본인인지 검증
-        users.validateDelete();         // 삭제 검증
+
         users.updateBy(requestDto);     // 업데이트
 
         return UserResponseDto.from(users);

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -10,6 +10,7 @@ import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +29,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public UserResponseDto updateUserById(Long id, AuthUser authUser, UpdateUserRequestDto requestDto) {
         Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -34,7 +34,7 @@ public class UserServiceImpl implements UserService {
         // 닉네임 변경 시 변경할 닉네임이 DB에 있으면 예외 발생
         if (!users.getNickname().equals(requestDto.getNickname()) &&
                 userRepository.existsByNickname(requestDto.getNickname())) {
-            throw new AuthException(ErrorCode.USER_EXIST_NICKNAME);
+            throw new GlobalException(ErrorCode.USER_EXIST_NICKNAME);
         }
 
         users.validateAccess(authUser); // 로그인한 보인인지 검증

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -37,7 +37,7 @@ public class UserServiceImpl implements UserService {
             throw new GlobalException(ErrorCode.USER_EXIST_NICKNAME);
         }
 
-        users.validateAccess(authUser); // 로그인한 보인인지 검증
+        users.validateAccess(authUser); // 로그인한 본인인지 검증
         users.validateDelete();         // 삭제 검증
         users.updateBy(requestDto);     // 업데이트
 

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,11 @@
+# application-test.properties
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# 중요!
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,6 +1,7 @@
 # 기본 메시지
 javax.validation.constraints.NotBlank.message=필수 입력 항목입니다.
 javax.validation.constraints.Email.message=이메일 형식이 올바르지 않습니다.
+javax.validation.constraints.NotNull.message=비어있을 수 없습니다.
 
 # Auth
 auth.email.notblank=이메일을 입력해 주세요.

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplIntegrationTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.delivery.igo.igo_delivery.api.user.service;
+
+import com.delivery.igo.igo_delivery.IgoDeliveryApplication;
+import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
+import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = IgoDeliveryApplication.class)
+@Transactional
+@ActiveProfiles("test")
+class UserServiceImplIntegrationTest {
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    UserServiceImpl userService;
+
+    @Test
+    void 유저_정보_수정_서비스_리포지토리_통합테스트_성공() {
+        // given
+        Users user = Users.builder()
+                .email("email@naver.com")
+                .nickname("정상유저")
+                .phoneNumber("010-1111-2222")
+                .password("encodedPassword")
+                .address("세상에없는구")
+                .userRole(UserRole.OWNER)
+                .userStatus(UserStatus.LIVE)
+                .build();
+        userRepository.save(user);
+
+        AuthUser authUser = new AuthUser(1L, "email@naver.com", "정상유저", UserRole.OWNER);
+        UpdateUserRequestDto requestDto = new UpdateUserRequestDto(
+                "수정할게요",
+                "010-9999-9999",
+                "수정된주소",
+                UserRole.CONSUMER);
+
+        // when
+        UserResponseDto userResponseDto = userService.updateUserById(1L, authUser, requestDto);
+
+        // then
+        // 요청값과 저장된 값이 일치함
+        assertEquals(requestDto.getNickname(), userResponseDto.getNickname());
+        assertEquals(requestDto.getPhoneNumber(), userResponseDto.getPhoneNumber());
+        assertEquals(requestDto.getAddress(), userResponseDto.getAddress());
+        assertEquals(requestDto.getRole().toString(), userResponseDto.getRole().toString());
+
+    }
+
+}

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplUnitTest.java
@@ -1,6 +1,6 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
-import com.delivery.igo.igo_delivery.api.user.dto.resonse.FindUserResponseDto;
+import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
 import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
@@ -46,7 +46,7 @@ class UserServiceImplUnitTest {
         given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
 
         // when
-        FindUserResponseDto findUserDto = userService.findUserById(1L, authUser);
+        UserResponseDto findUserDto = userService.findUserById(1L, authUser);
 
         // then
         assertEquals(user.getId(), findUserDto.getId());

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplUnitTest.java
@@ -1,5 +1,6 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
+import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
 import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
@@ -56,10 +57,9 @@ class UserServiceImplUnitTest {
     }
 
     @Test
-    void 내정보가_없으면_예외_발생_에러코드_USER_NOT_FOUND() {
+    void 내정보_조회시_내정보가_없으면_예외_발생_에러코드_USER_NOT_FOUND() {
         // given
         AuthUser authUser = new AuthUser(1L, "email@naver.com", "로그인유저", UserRole.OWNER);
-        given(userRepository.findById(authUser.getId())).willReturn(Optional.empty());
 
         // when & then
         GlobalException exception = assertThrows(GlobalException.class, () -> userService.findUserById(1L, authUser));
@@ -67,5 +67,36 @@ class UserServiceImplUnitTest {
         verify(userRepository).findById(authUser.getId());
 
     }
+
+    @Test
+    void 내정보_수정시_변경할_닉네임이_이미있다면_에러_발생_에러코드_USER_EXIST_NICKNAME() {
+        // given
+        Users user = Users.builder()
+                .id(1L)
+                .email("email@naver.com")
+                .nickname("정상유저")
+                .phoneNumber("010-1111-2222")
+                .address("세상에없는구")
+                .userRole(UserRole.OWNER)
+                .userStatus(UserStatus.LIVE)
+                .build();
+
+        AuthUser authUser = new AuthUser(1L, "email@naver.com", "정상유저", UserRole.OWNER);
+        UpdateUserRequestDto requestDto = new UpdateUserRequestDto("수정할게요",
+                "010-1111-1111",
+                "주소",
+                UserRole.CONSUMER);
+
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
+        given(userRepository.existsByNickname(requestDto.getNickname())).willReturn(true);
+
+        // when & then
+        GlobalException exception = assertThrows(GlobalException.class,
+                () -> userService.updateUserById(1L, authUser, requestDto));
+        assertEquals(ErrorCode.USER_EXIST_NICKNAME, exception.getErrorCode());
+        verify(userRepository).findById(authUser.getId());
+        verify(userRepository).existsByNickname(requestDto.getNickname());
+    }
+
 }
 


### PR DESCRIPTION
## Description
1. 내 정보 수정 API 개발
    - 내 정보가 없으면 예외 발생
    - 닉네임 변경 시 이미 있는 닉네임이라면 예외 발생
    - 로그인 본인 검증, 삭제 검증 적용
    - 요청값에 기본 벨리데이션 적용

2. DTO명 수정
    - 내 정보 조회와 수정 시 응답하는 필드가 같아서 공통으로 사용하는 Dto1개로 변경

3. 업데이트 시 발생되는 예외 케이스 단위테스트 추가
    - 다른 검증은 이미 기존에 테스트를 했으므로 수정할 닉네임이 DB에 있을 때 발생하는 예외 검증 테스트 진행

4. 업데이트 성공 케이스는 통합테스트로 진행
    - JPA의 더티체킹으로 업데이트가 진행되기 때문에 단위테스트로는 테스트가 의미가 없다고 판단하여 통합테스트로 진행
    - 통합테스트 진행을 위해 H2 DB 의존성 추가와 test 전용 application-test.properties를 추가

## Changes
- UserController, UserServiceImpl, Users 수정
- UpdateUserReqeustDto, UserResponseDto 추가
- FindUserResponseDto 삭제
- 단위테스트 추가
- 통합테스트 성공케이스 추가

## Screenshots
1. 단위 테스트 통과
![image](https://github.com/user-attachments/assets/5e35ba6f-3c4a-4d60-8ef7-b9c37a0d59bd)

2. 통합 테스트 통과
![image](https://github.com/user-attachments/assets/4b981a7e-2b66-4eb2-a153-9058b4ed5fc6)


3. 수정 성공
<img width="794" alt="image" src="https://github.com/user-attachments/assets/70d0e56c-9d12-4233-9f64-be023b5eb0d0" />

4. 널 검증
<img width="884" alt="image" src="https://github.com/user-attachments/assets/7df6c607-ba2e-4d51-b2f2-a46ea2648558" />


