### PR TITLE
[Users] 내 비밀번호 수정 API 개발 및 단위, 통합 테스트 및 도메인 메서드 방어코드 제거

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/controller/AuthController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/controller/AuthController.java
@@ -40,6 +40,6 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@Auth AuthUser authUser) {
         authService.logout(authUser);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/controller/UserController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/controller/UserController.java
@@ -34,7 +34,7 @@ public class UserController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<UserResponseDto> modifyMyInfo(@PathVariable Long id,
+    public ResponseEntity<UserResponseDto> updateMyInfo(@PathVariable Long id,
                                                         @Auth AuthUser authUser,
                                                         @Valid @RequestBody UpdateUserRequestDto requestDto) {
 
@@ -44,7 +44,7 @@ public class UserController {
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<Void> modifyMyPassword(@PathVariable Long id,
+    public ResponseEntity<Void> updateMyPassword(@PathVariable Long id,
                                                @Auth AuthUser authUser,
                                                @Valid @RequestBody UpdatePasswordRequestDto requestDto) {
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/controller/UserController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.delivery.igo.igo_delivery.api.user.controller;
 
+import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.api.user.service.UserService;
@@ -41,4 +42,15 @@ public class UserController {
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> modifyMyPassword(@PathVariable Long id,
+                                               @Auth AuthUser authUser,
+                                               @Valid @RequestBody UpdatePasswordRequestDto requestDto) {
+
+        userService.updateUserPasswordById(id, authUser, requestDto);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+
+    }
+
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/request/UpdatePasswordRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/request/UpdatePasswordRequestDto.java
@@ -1,0 +1,19 @@
+package com.delivery.igo.igo_delivery.api.user.dto.request;
+
+import com.delivery.igo.igo_delivery.common.annotation.Password;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdatePasswordRequestDto {
+
+    @NotBlank(message = "{auth.password.notblank}")
+    @Password(message = "{auth.password.invalid}")
+    private final String oldPassword;
+
+    @NotBlank(message = "{auth.password.notblank}")
+    @Password(message = "{auth.password.invalid}")
+    private final String newPassword;
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
@@ -1,7 +1,6 @@
 package com.delivery.igo.igo_delivery.api.user.entity;
 
 import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
-import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.entity.BaseEntity;

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
@@ -57,18 +57,10 @@ public class Users extends BaseEntity {
 
     // 내 정보 수정
     public void updateBy(UpdateUserRequestDto requestDto) {
-        if (requestDto.getNickname() != null) {
-            this.nickname = requestDto.getNickname();
-        }
-        if (requestDto.getPhoneNumber() != null) {
-            this.phoneNumber = requestDto.getPhoneNumber();
-        }
-        if (requestDto.getAddress() != null) {
-            this.address = requestDto.getAddress();
-        }
-        if (requestDto.getRole() != null) {
-            this.userRole = requestDto.getRole();
-        }
+        this.nickname = requestDto.getNickname();
+        this.phoneNumber = requestDto.getPhoneNumber();
+        this.address = requestDto.getAddress();
+        this.userRole = requestDto.getRole();
     }
 
     // 비밀번호 수정

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
@@ -1,6 +1,7 @@
 package com.delivery.igo.igo_delivery.api.user.entity;
 
 import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
+import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.entity.BaseEntity;
@@ -54,6 +55,7 @@ public class Users extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus userStatus;
 
+    // 내 정보 수정
     public void updateBy(UpdateUserRequestDto requestDto) {
         if (requestDto.getNickname() != null) {
             this.nickname = requestDto.getNickname();
@@ -67,6 +69,11 @@ public class Users extends BaseEntity {
         if (requestDto.getRole() != null) {
             this.userRole = requestDto.getRole();
         }
+    }
+
+    // 비밀번호 수정
+    public void updatePassword(String newPassword) {
+        password = newPassword;
     }
 
     // 삭제

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserService.java
@@ -1,11 +1,15 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
+import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import jakarta.validation.Valid;
 
 public interface UserService {
     UserResponseDto findUserById(Long id, AuthUser authUser);
 
     UserResponseDto updateUserById(Long id, AuthUser authUser, UpdateUserRequestDto requestDto);
+
+    void updateUserPasswordById(Long id, AuthUser authUser, UpdatePasswordRequestDto requestDto);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -7,7 +7,6 @@ import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
 import com.delivery.igo.igo_delivery.common.config.PasswordEncoder;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
-import com.delivery.igo.igo_delivery.common.exception.AuthException;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
@@ -45,7 +44,6 @@ public class UserServiceImpl implements UserService {
                 userRepository.existsByNickname(requestDto.getNickname())) {
             throw new GlobalException(ErrorCode.USER_EXIST_NICKNAME);
         }
-
 
         users.updateBy(requestDto);     // 업데이트
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -1,9 +1,11 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
+import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.config.PasswordEncoder;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.exception.AuthException;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
@@ -12,16 +14,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public UserResponseDto findUserById(Long id, AuthUser authUser) {
         Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
-        
+
         users.validateAccess(authUser); // 로그인한 본인인지 검증
         users.validateDelete(); // 삭제 검증, 삭제된 상태라면 404 예외 발생
 
@@ -45,5 +50,25 @@ public class UserServiceImpl implements UserService {
         users.updateBy(requestDto);     // 업데이트
 
         return UserResponseDto.from(users);
+    }
+
+    @Override
+    @Transactional
+    public void updateUserPasswordById(Long id, AuthUser authUser, UpdatePasswordRequestDto requestDto) {
+        // 기존 비밀번호와 같은 비밀번호로 요청이 들어올 경우 예외 발생
+        if (Objects.equals(requestDto.getOldPassword(), requestDto.getNewPassword())) {
+            throw new GlobalException(ErrorCode.PASSWORD_DUPLICATED);
+        }
+
+        Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+        users.validateAccess(authUser); // 로그인한 본인인지 검증
+        users.validateDelete();         // 삭제 검증
+
+        if (!passwordEncoder.matches(requestDto.getOldPassword(), users.getPassword())) {
+            throw new GlobalException(ErrorCode.PASSWORD_NOT_MATCHED);
+        }
+
+        String encodedPassword = passwordEncoder.encode(requestDto.getNewPassword());
+        users.updatePassword(encodedPassword);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
@@ -21,6 +21,9 @@ public enum ErrorCode {
     USER_EXIST_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     AUTH_TYPE_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, "@Auth와 AuthUser 타입은 함께 사용되어야 합니다."),
 
+    // password
+    PASSWORD_DUPLICATED(HttpStatus.BAD_REQUEST, "같은 비밀번호로 중복 요청할 수 없습니다"),
+    PASSWORD_NOT_MATCHED(HttpStatus.BAD_REQUEST, "기존 비밀번호가 다릅니다."),
 
     // JWT
     JWT_REQUIRED(HttpStatus.BAD_REQUEST, "JWT 토큰이 필요합니다."),

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplIntegrationTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplIntegrationTest.java
@@ -1,13 +1,17 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
 import com.delivery.igo.igo_delivery.IgoDeliveryApplication;
+import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
 import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.config.PasswordEncoder;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,24 +27,36 @@ class UserServiceImplIntegrationTest {
 
     @Autowired
     UserRepository userRepository;
+
     @Autowired
     UserServiceImpl userService;
 
-    @Test
-    void 유저_정보_수정_서비스_리포지토리_통합테스트_성공() {
-        // given
-        Users user = Users.builder()
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    Users user;
+    AuthUser authUser;
+
+    @BeforeEach
+    void testInit() {
+        user = Users.builder()
                 .email("email@naver.com")
                 .nickname("정상유저")
                 .phoneNumber("010-1111-2222")
-                .password("encodedPassword")
+                .password(passwordEncoder.encode("oldPassword123!@#"))
                 .address("세상에없는구")
                 .userRole(UserRole.OWNER)
                 .userStatus(UserStatus.LIVE)
                 .build();
+
         userRepository.save(user);
 
-        AuthUser authUser = new AuthUser(1L, "email@naver.com", "정상유저", UserRole.OWNER);
+        authUser = new AuthUser(user.getId(), "email@naver.com", "정상유저", UserRole.OWNER);
+    }
+
+    @Test
+    void 유저_정보_수정_서비스_리포지토리_통합테스트_성공() {
+        // given
         UpdateUserRequestDto requestDto = new UpdateUserRequestDto(
                 "수정할게요",
                 "010-9999-9999",
@@ -48,10 +64,9 @@ class UserServiceImplIntegrationTest {
                 UserRole.CONSUMER);
 
         // when
-        UserResponseDto userResponseDto = userService.updateUserById(1L, authUser, requestDto);
+        UserResponseDto userResponseDto = userService.updateUserById(user.getId(), authUser, requestDto);
 
-        // then
-        // 요청값과 저장된 값이 일치함
+        // then - 요청값과 저장된 값이 일치함
         assertEquals(requestDto.getNickname(), userResponseDto.getNickname());
         assertEquals(requestDto.getPhoneNumber(), userResponseDto.getPhoneNumber());
         assertEquals(requestDto.getAddress(), userResponseDto.getAddress());
@@ -59,4 +74,34 @@ class UserServiceImplIntegrationTest {
 
     }
 
+    @Test
+    void 유저_비밀번호_수정_서비스_리포지토리_통합테스트_성공() {
+        // given
+        UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("oldPassword123!@#", "newPassword123!@#");
+
+        // when
+        userService.updateUserPasswordById(user.getId(), authUser, requestDto);
+        Users findUsers = userRepository.findById(user.getId()).get();
+
+        // then
+        assertTrue(passwordEncoder.matches(requestDto.getNewPassword(), findUsers.getPassword()));
+        assertFalse(passwordEncoder.matches(requestDto.getOldPassword(), findUsers.getPassword()));
+    }
+
+    @Test
+    void 유저_비밀번호_수정이_실패하면_성공적으로_트랜잭션이_롤백_되어야함() {
+        // given
+        UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("oldPassword123!@#", "newPassword123!@#");
+        AuthUser otherAuthUser = new AuthUser(999L, "other@naver.com", "다른유저", UserRole.OWNER);
+
+        // when & then
+        assertThrows(GlobalException.class,
+                () -> userService.updateUserPasswordById(user.getId(), otherAuthUser, requestDto)); // 인증 유저와 비밀번호 변경 유저가 다름
+        Users findUsers = userRepository.findById(user.getId()).get();
+
+        // then - 비밀번호 변경 안됨
+        assertTrue(passwordEncoder.matches(requestDto.getOldPassword(), findUsers.getPassword()));  // 기존 비밀번호로 검증이 되어야함
+        assertFalse(passwordEncoder.matches(requestDto.getNewPassword(), findUsers.getPassword())); // 바꾸려하는 비밀번호로 검증이 안됨
+
+    }
 }

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplUnitTest.java
@@ -1,11 +1,13 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
+import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
 import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.config.PasswordEncoder;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.exception.GlobalException;
@@ -26,6 +28,9 @@ class UserServiceImplUnitTest {
 
     @Mock
     UserRepository userRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
 
     @InjectMocks
     UserServiceImpl userService;
@@ -59,7 +64,7 @@ class UserServiceImplUnitTest {
     @Test
     void 내정보_조회시_내정보가_없으면_예외_발생_에러코드_USER_NOT_FOUND() {
         // given
-        AuthUser authUser = new AuthUser(1L, "email@naver.com", "로그인유저", UserRole.OWNER);
+        AuthUser authUser = new AuthUser(1L, "email@naver.com", "정상유저", UserRole.OWNER);
 
         // when & then
         GlobalException exception = assertThrows(GlobalException.class, () -> userService.findUserById(1L, authUser));
@@ -98,5 +103,44 @@ class UserServiceImplUnitTest {
         verify(userRepository).existsByNickname(requestDto.getNickname());
     }
 
+    @Test
+    void 기존_비밀번호와_변경할_비밀번호가_동일하게_요청이오면_예외_발생_ErrorCode_PASSWORD_DUPLICATED() {
+        // given
+        AuthUser authUser = new AuthUser(1L, "email@naver.com", "정상유저", UserRole.OWNER);
+        UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("samePassword", "samePassword");
+
+        // when & then
+        GlobalException exception = assertThrows(GlobalException.class,
+                () -> userService.updateUserPasswordById(1L, authUser, requestDto));
+        assertEquals(ErrorCode.PASSWORD_DUPLICATED, exception.getErrorCode());
+
+    }
+
+    @Test
+    void 입력한_비밀번호가_DB에서_조회된_비밀번호를_매칭할때_다르면_예외_발생_ErrorCode_PASSWORD_NOT_MATCHED() {
+        // given
+        Users user = Users.builder()
+                .id(1L)
+                .email("email@naver.com")
+                .nickname("정상유저")
+                .phoneNumber("010-1111-2222")
+                .address("세상에없는구")
+                .password("encodedPassword")
+                .userRole(UserRole.OWNER)
+                .userStatus(UserStatus.LIVE)
+                .build();
+
+        AuthUser authUser = new AuthUser(1L, "email@naver.com", "정상유저", UserRole.OWNER);
+        UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("oldPassword", "newPassword");
+
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("oldPassword", "encodedPassword")).willReturn(false);
+
+        // when & then
+        GlobalException exception = assertThrows(GlobalException.class,
+                () -> userService.updateUserPasswordById(1L, authUser, requestDto));
+        assertEquals(ErrorCode.PASSWORD_NOT_MATCHED, exception.getErrorCode());
+
+    }
 }
 

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplUnitTest.java
@@ -11,6 +11,7 @@ import com.delivery.igo.igo_delivery.common.config.PasswordEncoder;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -35,20 +36,28 @@ class UserServiceImplUnitTest {
     @InjectMocks
     UserServiceImpl userService;
 
-    @Test
-    void 내정보가_정상적으로_조회됨() {
-        // given
-        Users user = Users.builder()
+    private Users user;
+    private AuthUser authUser;
+
+    @BeforeEach
+    void testInit() {
+        user = Users.builder()
                 .id(1L)
                 .email("email@naver.com")
                 .nickname("정상유저")
                 .phoneNumber("010-1111-2222")
                 .address("세상에없는구")
+                .password("encodedPassword")
                 .userRole(UserRole.OWNER)
                 .userStatus(UserStatus.LIVE)
                 .build();
 
-        AuthUser authUser = new AuthUser(1L, "email@naver.com", "정상유저", UserRole.OWNER);
+        authUser = new AuthUser(1L, "email@naver.com", "정상유저", UserRole.OWNER);
+    }
+
+    @Test
+    void 내정보가_정상적으로_조회됨() {
+        // given
         given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
 
         // when
@@ -76,17 +85,6 @@ class UserServiceImplUnitTest {
     @Test
     void 내정보_수정시_변경할_닉네임이_이미있다면_에러_발생_에러코드_USER_EXIST_NICKNAME() {
         // given
-        Users user = Users.builder()
-                .id(1L)
-                .email("email@naver.com")
-                .nickname("정상유저")
-                .phoneNumber("010-1111-2222")
-                .address("세상에없는구")
-                .userRole(UserRole.OWNER)
-                .userStatus(UserStatus.LIVE)
-                .build();
-
-        AuthUser authUser = new AuthUser(1L, "email@naver.com", "정상유저", UserRole.OWNER);
         UpdateUserRequestDto requestDto = new UpdateUserRequestDto("수정할게요",
                 "010-1111-1111",
                 "주소",
@@ -101,12 +99,12 @@ class UserServiceImplUnitTest {
         assertEquals(ErrorCode.USER_EXIST_NICKNAME, exception.getErrorCode());
         verify(userRepository).findById(authUser.getId());
         verify(userRepository).existsByNickname(requestDto.getNickname());
+
     }
 
     @Test
     void 기존_비밀번호와_변경할_비밀번호가_동일하게_요청이오면_예외_발생_ErrorCode_PASSWORD_DUPLICATED() {
         // given
-        AuthUser authUser = new AuthUser(1L, "email@naver.com", "정상유저", UserRole.OWNER);
         UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("samePassword", "samePassword");
 
         // when & then
@@ -119,18 +117,6 @@ class UserServiceImplUnitTest {
     @Test
     void 입력한_비밀번호가_DB에서_조회된_비밀번호를_매칭할때_다르면_예외_발생_ErrorCode_PASSWORD_NOT_MATCHED() {
         // given
-        Users user = Users.builder()
-                .id(1L)
-                .email("email@naver.com")
-                .nickname("정상유저")
-                .phoneNumber("010-1111-2222")
-                .address("세상에없는구")
-                .password("encodedPassword")
-                .userRole(UserRole.OWNER)
-                .userStatus(UserStatus.LIVE)
-                .build();
-
-        AuthUser authUser = new AuthUser(1L, "email@naver.com", "정상유저", UserRole.OWNER);
         UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("oldPassword", "newPassword");
 
         given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));


### PR DESCRIPTION
## Description
1. 비밀번호 수정 API 개발
    - 기존 비밀번호와 동일한 비밀번호로 수정할경우 예외 발생
    - DB에 저장된 비밀번호과 기존의 비밀번호를 매칭하여 다를 경우 예외 발생
    - 조회할 대상이 없거나 삭제 되었거나 로그인한 유저와 다를 경우 예외 발생(기존 API에서 검증 완료)
    - 모든 로직이 정상 통과가 되면 인코딩된 비밀번호를 더티체킹으로 비밀번호 업데이트 실시

2. 단위 및 통합 테스트
    - 비밀번호 수정 시 발생하는 예외 케이스는 단위 테스트로 수행
    - 비밀번호 수정 성공 케이스는 통합테스트로 진행
    - 비밀번호 수정 시 예외가 발생하면 성공적으로 트랜잭션 롤백이 되는 통합 테스트도 수행

3. 클린코드 리펙토링 관련 - 도메인 방어로직
    - 유저 정보수정, 유저 비밀번호 수정 시 bean validation에서 안전하게 검증 했지만 도메인에서도 검증하는 것이 불안요소를 제거하는 것이 좋다고 생각하여 방어로직을 추가하였음
    - 그러나 유빈님의 코멘트와 추가적인 의문이 들어 찾아본 결과 클린코드(신뢰 기반) VS 방어 코드 관점으로 논쟁이 있는 부분이 있다는 것을 확인함
    - 일단 기본적으로 도메인 자체에서 입력값 검증을 하는 것은 현재의 일반적인 설계 관점에서는 과한 방어라고 보여일 여지가 있다고 하여 도메인에서 null 검증 코드를 제거하고 bean validation 검증만으로 문제를 해결
    - https://www.notion.so/teamsparta/1-I-1ce2dc3ef514804494bdd5684937b8f2?p=1e02dc3ef51480a3bd69ee98a89741ab&pm=s

4. 기타
    - 응답없는 API의 응답 성공 상태코드를 204로 일부 수정

## Changes
- Users, UserController, UserServiceImpl - 수정
- UserServiceImpl 단위, 통합 테스트 - 수정

## Screenshots
1. UserServiceImpl 단위, 통합 테스트 모두 성공
![image](https://github.com/user-attachments/assets/aadcdfd6-dbcc-4b02-a417-e51a283919ae)

2. 비밀번호 변경 성공
![image](https://github.com/user-attachments/assets/f6831866-3d5e-4974-a7a4-67947f9f4b39)

