### PR TITLE
[Users] 회원 탈퇴 API 개발 및 통합 테스트 진행, 불필요한 import 제거

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/controller/UserController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.delivery.igo.igo_delivery.api.user.controller;
 
+import com.delivery.igo.igo_delivery.api.user.dto.request.DeleteUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
@@ -53,4 +54,13 @@ public class UserController {
 
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id,
+                                           @Auth AuthUser authUser,
+                                           @Valid @RequestBody DeleteUserRequestDto requestDto) {
+
+        userService.deleteUser(id, authUser, requestDto);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/request/DeleteUserRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/dto/request/DeleteUserRequestDto.java
@@ -1,0 +1,15 @@
+package com.delivery.igo.igo_delivery.api.user.dto.request;
+
+import com.delivery.igo.igo_delivery.common.annotation.Password;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteUserRequestDto {
+    @NotBlank(message = "{auth.password.notblank}")
+    @Password(message = "{auth.password.invalid}")
+    private final String password;
+
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
@@ -54,7 +54,7 @@ public class Users extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus userStatus;
 
-    // 내 정보 수정
+    // 내 정보 수정 -> 멀티 모듈 프로젝트?일때 문제 발생가능성
     public void updateBy(UpdateUserRequestDto requestDto) {
         this.nickname = requestDto.getNickname();
         this.phoneNumber = requestDto.getPhoneNumber();

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
+import com.delivery.igo.igo_delivery.api.user.dto.request.DeleteUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
@@ -12,4 +13,6 @@ public interface UserService {
     UserResponseDto updateUserById(Long id, AuthUser authUser, UpdateUserRequestDto requestDto);
 
     void updateUserPasswordById(Long id, AuthUser authUser, UpdatePasswordRequestDto requestDto);
+
+    void deleteUser(Long id, AuthUser authUser, DeleteUserRequestDto requestDto);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserService.java
@@ -5,7 +5,6 @@ import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestD
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
-import jakarta.validation.Valid;
 
 public interface UserService {
     UserResponseDto findUserById(Long id, AuthUser authUser);

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -25,9 +25,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserResponseDto findUserById(Long id, AuthUser authUser) {
-        Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
-        users.validateAccess(authUser); // 로그인한 본인인지 검증
-        users.validateDelete(); // 삭제 검증, 삭제된 상태라면 404 예외 발생
+        Users users = getValidatedUser(id, authUser);   // 검증된 유저를 꺼내는 메서드
 
         return UserResponseDto.from(users);
     }
@@ -35,9 +33,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public UserResponseDto updateUserById(Long id, AuthUser authUser, UpdateUserRequestDto requestDto) {
-        Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
-        users.validateAccess(authUser); // 로그인한 본인인지 검증
-        users.validateDelete();         // 삭제 검증
+        Users users = getValidatedUser(id, authUser);   // 검증된 유저를 꺼내는 메서드
 
         // 닉네임 변경 시 변경할 닉네임이 DB에 있으면 예외 발생
         if (!users.getNickname().equals(requestDto.getNickname()) &&
@@ -58,9 +54,7 @@ public class UserServiceImpl implements UserService {
             throw new GlobalException(ErrorCode.PASSWORD_DUPLICATED);
         }
 
-        Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
-        users.validateAccess(authUser); // 로그인한 본인인지 검증
-        users.validateDelete();         // 삭제 검증
+        Users users = getValidatedUser(id, authUser);   // 검증된 유저를 꺼내는 메서드
 
         if (!passwordEncoder.matches(requestDto.getOldPassword(), users.getPassword())) {
             throw new GlobalException(ErrorCode.PASSWORD_NOT_MATCHED);
@@ -73,14 +67,21 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void deleteUser(Long id, AuthUser authUser, DeleteUserRequestDto requestDto) {
-        Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
-        users.validateAccess(authUser); // 로그인한 본인인지 검증
-        users.validateDelete();
+        Users users = getValidatedUser(id, authUser);   // 검증된 유저를 꺼내는 메서드
 
         if (!passwordEncoder.matches(requestDto.getPassword(), users.getPassword())) {
             throw new GlobalException(ErrorCode.PASSWORD_NOT_MATCHED);
         }
 
         users.delete();
+    }
+
+    // UserServiceImpl 모든 메서드에서 공통적으로 사용되는 User 검증을 private 메서드화 하여 재사용하도록 변경
+    private Users getValidatedUser(Long id, AuthUser authUser) {
+        // 유저가 없으면 예외
+        Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+        users.validateAccess(authUser); // 로그인한 본인인지 검증
+        users.validateDelete();         // 삭제 되었는지 검증
+        return users;
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -25,7 +25,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserResponseDto findUserById(Long id, AuthUser authUser) {
-        Users users = getValidatedUser(id, authUser);   // 검증된 유저를 꺼내는 메서드
+        Users users = getUserWithAccessCheck(id, authUser);   // 검증된 유저를 꺼내는 메서드
 
         return UserResponseDto.from(users);
     }
@@ -33,7 +33,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public UserResponseDto updateUserById(Long id, AuthUser authUser, UpdateUserRequestDto requestDto) {
-        Users users = getValidatedUser(id, authUser);   // 검증된 유저를 꺼내는 메서드
+        Users users = getUserWithAccessCheck(id, authUser);
 
         // 닉네임 변경 시 변경할 닉네임이 DB에 있으면 예외 발생
         if (!users.getNickname().equals(requestDto.getNickname()) &&
@@ -41,7 +41,7 @@ public class UserServiceImpl implements UserService {
             throw new GlobalException(ErrorCode.USER_EXIST_NICKNAME);
         }
 
-        users.updateBy(requestDto);     // 업데이트
+        users.updateBy(requestDto);
 
         return UserResponseDto.from(users);
     }
@@ -54,7 +54,7 @@ public class UserServiceImpl implements UserService {
             throw new GlobalException(ErrorCode.PASSWORD_DUPLICATED);
         }
 
-        Users users = getValidatedUser(id, authUser);   // 검증된 유저를 꺼내는 메서드
+        Users users = getUserWithAccessCheck(id, authUser);
 
         if (!passwordEncoder.matches(requestDto.getOldPassword(), users.getPassword())) {
             throw new GlobalException(ErrorCode.PASSWORD_NOT_MATCHED);
@@ -67,7 +67,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void deleteUser(Long id, AuthUser authUser, DeleteUserRequestDto requestDto) {
-        Users users = getValidatedUser(id, authUser);   // 검증된 유저를 꺼내는 메서드
+        Users users = getUserWithAccessCheck(id, authUser);   // 검증된 유저를 꺼내는 메서드
 
         if (!passwordEncoder.matches(requestDto.getPassword(), users.getPassword())) {
             throw new GlobalException(ErrorCode.PASSWORD_NOT_MATCHED);
@@ -77,7 +77,7 @@ public class UserServiceImpl implements UserService {
     }
 
     // UserServiceImpl 모든 메서드에서 공통적으로 사용되는 User 검증을 private 메서드화 하여 재사용하도록 변경
-    private Users getValidatedUser(Long id, AuthUser authUser) {
+    private Users getUserWithAccessCheck(Long id, AuthUser authUser) {
         // 유저가 없으면 예외
         Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
         users.validateAccess(authUser); // 로그인한 본인인지 검증

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
+import com.delivery.igo.igo_delivery.api.user.dto.request.DeleteUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
@@ -25,7 +26,6 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserResponseDto findUserById(Long id, AuthUser authUser) {
         Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
-
         users.validateAccess(authUser); // 로그인한 본인인지 검증
         users.validateDelete(); // 삭제 검증, 삭제된 상태라면 404 예외 발생
 
@@ -68,5 +68,19 @@ public class UserServiceImpl implements UserService {
 
         String encodedPassword = passwordEncoder.encode(requestDto.getNewPassword());
         users.updatePassword(encodedPassword);
+    }
+
+    @Override
+    @Transactional
+    public void deleteUser(Long id, AuthUser authUser, DeleteUserRequestDto requestDto) {
+        Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+        users.validateAccess(authUser); // 로그인한 본인인지 검증
+        users.validateDelete();
+
+        if (!passwordEncoder.matches(requestDto.getPassword(), users.getPassword())) {
+            throw new GlobalException(ErrorCode.PASSWORD_NOT_MATCHED);
+        }
+
+        users.delete();
     }
 }

--- a/src/test/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImplTest.java
@@ -1,7 +1,5 @@
 package com.delivery.igo.igo_delivery.api.review.service;
 
-import com.delivery.igo.igo_delivery.api.menu.dto.request.MenuRequestDto;
-import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuResponseDto;
 import com.delivery.igo.igo_delivery.api.menu.entity.MenuStatus;
 import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
 import com.delivery.igo.igo_delivery.api.menu.repository.MenuRepository;
@@ -20,8 +18,6 @@ import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,14 +25,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImplTest.java
@@ -89,7 +89,7 @@ public class ReviewServiceImplTest {
         order = Orders.builder()
                 .id(1L)
                 .users(user)
-                .orderStatus(OrderStatus.LIVE)
+                .orderStatus(OrderStatus.CANCELLED)
                 .orderAddress("부산시")
                 .build();
 

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplIntegrationTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
 import com.delivery.igo.igo_delivery.IgoDeliveryApplication;
+import com.delivery.igo.igo_delivery.api.user.dto.request.DeleteUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.resonse.UserResponseDto;
@@ -19,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(classes = IgoDeliveryApplication.class)
 @Transactional
@@ -99,9 +101,32 @@ class UserServiceImplIntegrationTest {
                 () -> userService.updateUserPasswordById(user.getId(), otherAuthUser, requestDto)); // 인증 유저와 비밀번호 변경 유저가 다름
         Users findUsers = userRepository.findById(user.getId()).get();
 
-        // then - 비밀번호 변경 안됨
         assertTrue(passwordEncoder.matches(requestDto.getOldPassword(), findUsers.getPassword()));  // 기존 비밀번호로 검증이 되어야함
         assertFalse(passwordEncoder.matches(requestDto.getNewPassword(), findUsers.getPassword())); // 바꾸려하는 비밀번호로 검증이 안됨
 
+    }
+
+    @Test
+    void 비밀번호_수정이_정상적으로_성공() {
+        // given
+        DeleteUserRequestDto requestDto = new DeleteUserRequestDto("oldPassword123!@#");
+
+        // when
+        userService.deleteUser(user.getId(), authUser, requestDto);
+
+        // then
+        assertEquals(UserStatus.INACTIVE, user.getUserStatus());
+    }
+
+    @Test
+    void 비밀번호_수정이_실패하면_트랜잭션롤백() {
+        // given
+        DeleteUserRequestDto requestDto = new DeleteUserRequestDto("oldPassword123!@#");
+        AuthUser otherAuthUser = new AuthUser(999L, "other@naver.com", "다른유저", UserRole.OWNER);
+
+        // when & then
+        assertThrows(GlobalException.class, () -> userService.deleteUser(user.getId(), otherAuthUser, requestDto));
+        assertEquals(UserStatus.LIVE, user.getUserStatus());
+        assertNotEquals(UserStatus.INACTIVE, user.getUserStatus());
     }
 }

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplIntegrationTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplIntegrationTest.java
@@ -72,7 +72,7 @@ class UserServiceImplIntegrationTest {
         assertEquals(requestDto.getNickname(), userResponseDto.getNickname());
         assertEquals(requestDto.getPhoneNumber(), userResponseDto.getPhoneNumber());
         assertEquals(requestDto.getAddress(), userResponseDto.getAddress());
-        assertEquals(requestDto.getRole().toString(), userResponseDto.getRole().toString());
+        assertEquals(requestDto.getRole().toString(), userResponseDto.getRole());
 
     }
 


### PR DESCRIPTION
## Description
1.  회원 탈퇴 API 개발
    - 회원 탈퇴시 유저의 상태를 INACTIVE로 변경
    - 유저 검증(유저 없음, 삭제된 유저, 본인이 아닌 유저는 예외)와 비밀번호 매칭 실패 검증 적용
    - 회원이 탈퇴되면 클라이언트에서 토큰을 삭제하여 로그아웃처리(현재는 무상태 서버임)

2. UserServiceImpl에서 반복적으로 나오는 검증 로직을 private화
    - 해당 클래스의 모든 메서드에서 반복적으로 등장하는 User조회 및 검증 로직을 단일 private 메서드로 묶어서 재사용성을 높이고 서비스 로직의 코드를 가독성있게 수정

3. 일부 불필요한 import와 코드 제거
    - 테스트 코드의 import들 및 toString() 제거

## Changes
- Users, UserController, UserServiceImpl 수정
- Users 통합 테스트 수정

## Screenshots
1. 회원 탈퇴 성공
![image](https://github.com/user-attachments/assets/3e4f890a-0830-46c5-abb1-5e4689fb7be0)
![image](https://github.com/user-attachments/assets/3f208f58-9eba-422f-bf8a-54db1e8f760c)


2. 회원 탈퇴 통합 테스트 성공
![image](https://github.com/user-attachments/assets/6f6203b6-2368-4e00-9df0-62ef7df09281)
