### PR TITLE
[Review] feat & fix: 리뷰 생성 기능 검증 로직 수정 & 테스트 케이스 전체 추가

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/review/dto/ReviewRequestDto.java
@@ -21,7 +21,7 @@ public class ReviewRequestDto {
     @NotBlank(message = "{review.content.notblank}")
     private String content;
 
-    @NotBlank(message = "{review.rating.notblank}")
+    @NotNull(message = "{review.rating.notnull}")
     @Range(min = 1, max = 5, message = "{review.rating.outofband}")
     private Integer rating;
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -40,5 +40,5 @@ store.minOrderPrice.min=최소 주문 금액은 10000원 이상이어야 합니�
 review.order.notblank=주문 번호를 입력해주세요.
 review.store.notblank=매장 번호를 입력해주세요.
 review.content.notblank=리뷰 내용을 입력해주세요.
-review.rating.notblank=별점을 입력해주세요.
+review.rating.notnull=별점을 입력해주세요.
 review.rating.outofband=별점은 1-5점 사이의 정수값을 입력해주세요.

--- a/src/test/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImplTest.java
@@ -2,7 +2,6 @@ package com.delivery.igo.igo_delivery.api.review.service;
 
 import com.delivery.igo.igo_delivery.api.menu.entity.MenuStatus;
 import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
-import com.delivery.igo.igo_delivery.api.menu.repository.MenuRepository;
 import com.delivery.igo.igo_delivery.api.order.entity.OrderItems;
 import com.delivery.igo.igo_delivery.api.order.entity.OrderStatus;
 import com.delivery.igo.igo_delivery.api.order.entity.Orders;

--- a/src/test/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImplTest.java
@@ -56,9 +56,6 @@ public class ReviewServiceImplTest {
     @Mock
     private StoreRepository storeRepository;
 
-    @Mock
-    private MenuRepository menuRepository;
-
     @InjectMocks
     private ReviewServiceImpl reviewService;
 

--- a/src/test/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImplTest.java
@@ -167,40 +167,6 @@ public class ReviewServiceImplTest {
     }
 
     @Test
-    void createReview_주문이_없으면_ORDER_NOT_FOUND_에러를_던진다() {
-        // given
-        ReviewRequestDto requestDto = new ReviewRequestDto(1L,1L,"리뷰내용",5);
-
-        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
-        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.empty()); // 주문 없음 처리
-
-        // when
-        GlobalException exception = assertThrows(GlobalException.class, ()->
-                reviewService.createReview(authUser,requestDto)
-        );
-
-        // then
-        assertEquals(ErrorCode.ORDER_NOT_FOUND, exception.getErrorCode());
-    }
-
-    @Test
-    void createReview_가게가_없으면_STORE_NOT_FOUND_예외를_던진다() {
-        // given
-        ReviewRequestDto requestDto = new ReviewRequestDto(1L, 1L, "리뷰내용", 5);
-
-        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
-        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(order)); // 주문 없음 처리
-        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.empty());
-
-        // when
-        GlobalException exception = assertThrows(GlobalException.class, () ->
-                reviewService.createReview(authUser, requestDto));
-
-        // then
-        assertEquals(ErrorCode.STORE_NOT_FOUND, exception.getErrorCode());
-    }
-
-    @Test
     void createReview_유저상태가_INACTIVE면_DELETED_USER_예외를_던진다() {
         // given
         ReviewRequestDto requestDto = new ReviewRequestDto(1L, 1L, "리뷰 내용", 5);
@@ -212,8 +178,6 @@ public class ReviewServiceImplTest {
                 .userStatus(UserStatus.INACTIVE)
                 .build();
         given(userRepository.findById(authUser.getId())).willReturn(Optional.of(deletedUser));
-        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(order));
-        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.of(store));
 
         // when
         GlobalException exception = assertThrows(GlobalException.class, ()->
@@ -235,8 +199,6 @@ public class ReviewServiceImplTest {
                 .userStatus(UserStatus.LIVE)
                 .build();
         given(userRepository.findById(authUser.getId())).willReturn(Optional.of(owner));
-        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(order));
-        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.of(store));
 
         // when
         GlobalException exception = assertThrows(GlobalException.class, () ->
@@ -244,6 +206,23 @@ public class ReviewServiceImplTest {
 
         // then
         assertEquals(ErrorCode.ROLE_CONSUMER_FORBIDDEN, exception.getErrorCode());
+    }
+
+    @Test
+    void createReview_주문이_없으면_ORDER_NOT_FOUND_에러를_던진다() {
+        // given
+        ReviewRequestDto requestDto = new ReviewRequestDto(1L,1L,"리뷰내용",5);
+
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
+        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.empty()); // 주문 없음 처리
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, ()->
+                reviewService.createReview(authUser,requestDto)
+        );
+
+        // then
+        assertEquals(ErrorCode.ORDER_NOT_FOUND, exception.getErrorCode());
     }
 
     @Test
@@ -268,7 +247,6 @@ public class ReviewServiceImplTest {
 
         given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
         given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(orderByAnotherUser));
-        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.of(store));
 
         // when
         GlobalException exception = assertThrows(GlobalException.class, ()->
@@ -290,7 +268,6 @@ public class ReviewServiceImplTest {
                 .build();
         given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
         given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(incompleteOrder));
-        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.of(store));
 
         // when
         GlobalException exception = assertThrows(GlobalException.class, () ->
@@ -299,6 +276,23 @@ public class ReviewServiceImplTest {
 
         // then
         assertEquals(ErrorCode.REVIEW_ORDER_INVALID, exception.getErrorCode());
+    }
+
+    @Test
+    void createReview_가게가_없으면_STORE_NOT_FOUND_예외를_던진다() {
+        // given
+        ReviewRequestDto requestDto = new ReviewRequestDto(1L, 1L, "리뷰내용", 5);
+
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
+        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(order)); // 주문 없음 처리
+        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.empty());
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                reviewService.createReview(authUser, requestDto));
+
+        // then
+        assertEquals(ErrorCode.STORE_NOT_FOUND, exception.getErrorCode());
     }
 
     @Test

--- a/src/test/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImplTest.java
@@ -1,7 +1,5 @@
 package com.delivery.igo.igo_delivery.api.review.service;
 
-import com.delivery.igo.igo_delivery.api.menu.dto.request.MenuRequestDto;
-import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuResponseDto;
 import com.delivery.igo.igo_delivery.api.menu.entity.MenuStatus;
 import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
 import com.delivery.igo.igo_delivery.api.menu.repository.MenuRepository;
@@ -17,11 +15,12 @@ import com.delivery.igo.igo_delivery.api.review.repository.ReviewRepository;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;
 import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
 import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,14 +28,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -84,6 +83,7 @@ public class ReviewServiceImplTest {
                 .email("test@gmail.com")
                 .nickname("nickname")
                 .userRole(UserRole.CONSUMER)
+                .userStatus(UserStatus.LIVE)
                 .build();
 
         order = Orders.builder()
@@ -118,15 +118,14 @@ public class ReviewServiceImplTest {
     }
 
     @Test
-    void reviews_리뷰_생성에_성공한다() {
+    void createReview_리뷰_생성에_성공한다() {
         //given
         ReviewRequestDto requestDto = new ReviewRequestDto(1L, 1L, "컨텐츠", 5);
         Reviews review = Reviews.of(user, order, store, requestDto);
-        Long storeId = 1L;
 
         given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
-        given(orderRepository.findById(order.getId())).willReturn(Optional.of(order));
-        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(order));
+        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.of(store));
         given(orderItemsRepository.findByOrdersId(requestDto.getOrdersId())).willReturn(List.of(orderItem));
         given(reviewRepository.save(any())).willReturn(review);
 
@@ -137,12 +136,228 @@ public class ReviewServiceImplTest {
 
         //then
         verify(userRepository).findById(authUser.getId());
-        verify(orderRepository).findById(order.getId());
-        verify(storeRepository).findById(storeId);
-        verify(orderItemsRepository).findByOrdersId(order.getId());
+        verify(orderRepository).findById(requestDto.getOrdersId());
+        verify(storeRepository).findById(requestDto.getStoresId());
+        verify(orderItemsRepository).findByOrdersId(requestDto.getOrdersId());
         verify(reviewRepository).save(any(Reviews.class));
     }
 
+    @Test
+    void createReview_authUser가_null이면_USER_NOT_FOUND_예외를_던진다() {
+        // given
+        ReviewRequestDto requestDto = new ReviewRequestDto(1L, 1L, "리뷰내용", 5);
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                reviewService.createReview(null, requestDto));
+
+        // then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void createReview_유저가_없으면_USER_NOT_FOUND_예외를_던진다() {
+        // given
+        ReviewRequestDto requestDto = new ReviewRequestDto(1L,1L,"리뷰내용",5);
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.empty());
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, ()->
+                reviewService.createReview(authUser, requestDto)
+        );
+
+        // then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void createReview_주문이_없으면_ORDER_NOT_FOUND_에러를_던진다() {
+        // given
+        ReviewRequestDto requestDto = new ReviewRequestDto(1L,1L,"리뷰내용",5);
+
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
+        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.empty()); // 주문 없음 처리
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, ()->
+                reviewService.createReview(authUser,requestDto)
+        );
+
+        // then
+        assertEquals(ErrorCode.ORDER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void createReview_가게가_없으면_STORE_NOT_FOUND_예외를_던진다() {
+        // given
+        ReviewRequestDto requestDto = new ReviewRequestDto(1L, 1L, "리뷰내용", 5);
+
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
+        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(order)); // 주문 없음 처리
+        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.empty());
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                reviewService.createReview(authUser, requestDto));
+
+        // then
+        assertEquals(ErrorCode.STORE_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void createReview_유저상태가_INACTIVE면_DELETED_USER_예외를_던진다() {
+        // given
+        ReviewRequestDto requestDto = new ReviewRequestDto(1L, 1L, "리뷰 내용", 5);
+        Users deletedUser = Users.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .nickname("nickname")
+                .userRole(UserRole.CONSUMER)
+                .userStatus(UserStatus.INACTIVE)
+                .build();
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(deletedUser));
+        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(order));
+        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.of(store));
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, ()->
+                reviewService.createReview(authUser, requestDto));
+
+        // then
+        assertEquals(ErrorCode.DELETED_USER, exception.getErrorCode());
+    }
+
+    @Test
+    void createReview_유저권한이_CONSUMER가_아니면_ROLE_CONSUMER_FORBIDDEN_예외를_던진다() {
+        // given
+        ReviewRequestDto requestDto = new ReviewRequestDto(1L, 1L, "리뷰 내용", 5);
+        Users owner = Users.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .nickname("nickname")
+                .userRole(UserRole.OWNER)
+                .userStatus(UserStatus.LIVE)
+                .build();
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(owner));
+        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(order));
+        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.of(store));
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                reviewService.createReview(authUser, requestDto));
+
+        // then
+        assertEquals(ErrorCode.ROLE_CONSUMER_FORBIDDEN, exception.getErrorCode());
+    }
+
+    @Test
+    void createReview_본인주문이_아니면_FORBIDDEN_예외를_던진다() {
+        // given
+        ReviewRequestDto requestDto = new ReviewRequestDto(1L, 1L, "리뷰 내용", 5);
+        Users anotherUser = Users.builder()
+                .id(2L)// authUser와 다른 ID
+                .email("hacker@naver.com")
+                .nickname("침입자")
+                .userRole(UserRole.CONSUMER)
+                .userStatus(UserStatus.LIVE)
+                .build();
+
+        Orders orderByAnotherUser = Orders.builder()
+                .id(1L)
+                .users(anotherUser)
+                .orderStatus(OrderStatus.COMPLETE)
+                .orderAddress("서울시")
+                .build();
 
 
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
+        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(orderByAnotherUser));
+        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.of(store));
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, ()->
+                reviewService.createReview(authUser, requestDto));
+
+        // then
+        assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
+    }
+
+    @Test
+    void createReview_주문상태가_COMPLETE가_아니면_REVIEW_ORDER_INVALID_예외를_던진다(){
+        // given
+        ReviewRequestDto requestDto = new ReviewRequestDto(1L, 1L, "리뷰 내용", 5);
+        Orders incompleteOrder = Orders.builder()
+                .id(1L)
+                .users(user)
+                .orderStatus(OrderStatus.CANCELLED)
+                .orderAddress("부산시")
+                .build();
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
+        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(incompleteOrder));
+        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.of(store));
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                reviewService.createReview(authUser, requestDto)
+        );
+
+        // then
+        assertEquals(ErrorCode.REVIEW_ORDER_INVALID, exception.getErrorCode());
+    }
+
+    @Test
+    void createReview_주문상품이_없으면_REVIEW_ORDERITEM_NOT_FOUND_예외를_던진다() {
+        // given
+        ReviewRequestDto requestDto = new ReviewRequestDto(1L, 1L, "리뷰 내용", 5);
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
+        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(order));
+        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.of(store));
+        given(orderItemsRepository.findByOrdersId(requestDto.getOrdersId())).willReturn(List.of()); // 빈 리스트 반환
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                reviewService.createReview(authUser, requestDto));
+
+        // then
+        assertEquals(ErrorCode.REVIEW_ORDERITEM_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void createReview_주문과_가게가_매칭되지_않으면_REVIEW_STORE_MISMATCH_예외를_던진다() {
+        // given
+        ReviewRequestDto requestDto = new ReviewRequestDto(1L, 1L, "리뷰 내용", 5);
+        Stores anotherStore = Stores.builder()
+                .id(2L) // 가게 번호를 requestDto와 다르게 설정
+                .users(user)
+                .storeName("가게")
+                .build();
+
+        Menus anotherMenu = Menus.builder()
+                .id(1L)
+                .stores(anotherStore)
+                .menuName("메뉴이름")
+                .price(10000L)
+                .menuStatus(MenuStatus.LIVE)
+                .build();
+
+        OrderItems anotherOrderItem = OrderItems.builder()
+                .id(1L)
+                .orders(order)
+                .menus(anotherMenu)
+                .orderItemPrice(10000L)
+                .orderQuantity(1)
+                .build();
+
+        given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
+        given(orderRepository.findById(requestDto.getOrdersId())).willReturn(Optional.of(order));
+        given(storeRepository.findById(requestDto.getStoresId())).willReturn(Optional.of(store));
+        given(orderItemsRepository.findByOrdersId(requestDto.getOrdersId())).willReturn(List.of(anotherOrderItem)); //
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                reviewService.createReview(authUser, requestDto));
+
+        // then
+        assertEquals(ErrorCode.REVIEW_STORE_MISMATCH, exception.getErrorCode());
+    }
 }


### PR DESCRIPTION
## Description
- ReviewServiceImpl 클래스 수정: 검증 로직 순서를 변경하였습니다. (requestDto 필드값 DB 존재 여부 확인 > 자격 검증 > 유효성 검증 순)
- ReviewServiceImplTest 클래스 수정: ReviewServiceImpl 클래스 내 createReview 메서드에서 발생하는 모든 예외 상황에 대한 테스트케이스를 추가하였습니다.

## Changes
0. createReview_리뷰_생성에_성공한다() 내부 입력 인자 수정
1. createReview_authUser가_null이면_USER_NOT_FOUND_예외를_던진다
2. createReview_유저가_없으면_USER_NOT_FOUND_예외를_던진다()
3. createReview_주문이_없으면_ORDER_NOT_FOUND_에러를_던진다()
4. createReview_가게가_없으면_STORE_NOT_FOUND_예외를_던진다()
5. createReview_유저상태가_INACTIVE면_DELETED_USER_예외를_던진다()
6. createReview_유저권한이_CONSUMER가_아니면_ROLE_CONSUMER_FORBIDDEN_예외를_던진다()
7. createReview_본인주문이_아니면_FORBIDDEN_예외를_던진다()
8. createReview_주문상태가_COMPLETE가_아니면_REVIEW_ORDER_INVALID_예외를_던진다()
9. createReview_주문상품이_없으면_REVIEW_ORDERITEM_NOT_FOUND_예외를_던진다()
10. createReview_주문과_가게가_매칭되지_않으면_REVIEW_STORE_MISMATCH_예외를_던진다()

## Screenshots
![image](https://github.com/user-attachments/assets/d278dac5-0845-4f50-8b78-ce5a0b1989cb)