### PR TITLE
[Users][Auth] 회원탈퇴 API에 장바구니와 장바구니아이템 삭제 로직 추가, Users 의존성 관련 리펙토링

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImpl.java
@@ -6,6 +6,7 @@ import com.delivery.igo.igo_delivery.api.auth.dto.response.LoginResponseDto;
 import com.delivery.igo.igo_delivery.api.auth.dto.response.SignupResponseDto;
 import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
 import com.delivery.igo.igo_delivery.api.cart.repository.CartRepository;
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
 import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
@@ -39,10 +40,10 @@ public class AuthServiceImpl implements AuthService {
         }
 
         String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+        UserRole userRole = UserRole.of(requestDto.getUserRole());
+        Users newUser = buildUser(requestDto, encodedPassword, userRole);
 
-        Users newUser = Users.of(requestDto, encodedPassword);
         Users savedUser = userRepository.save(newUser);
-
         cartRepository.save(new Carts(savedUser));
 
         return SignupResponseDto.of(savedUser);
@@ -70,5 +71,17 @@ public class AuthServiceImpl implements AuthService {
         if (!user.getId().equals(authUser.getId())) {
             throw new AuthException(ErrorCode.FORBIDDEN);
         }
+    }
+
+    private Users buildUser(SignupRequestDto requestDto, String encodedPassword, UserRole userRole) {
+        return Users.builder()
+                .email(requestDto.getEmail())
+                .nickname(requestDto.getNickname())
+                .phoneNumber(requestDto.getPhoneNumber())
+                .password(encodedPassword)
+                .address(requestDto.getAddress())
+                .userRole(userRole)
+                .userStatus(UserStatus.LIVE)
+                .build();
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/repository/CartItemsRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/repository/CartItemsRepository.java
@@ -4,8 +4,6 @@ import com.delivery.igo.igo_delivery.api.cart.entity.CartItems;
 import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
 import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/repository/CartItemsRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/repository/CartItemsRepository.java
@@ -4,6 +4,8 @@ import com.delivery.igo.igo_delivery.api.cart.entity.CartItems;
 import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
 import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +16,6 @@ public interface CartItemsRepository extends JpaRepository<CartItems, Long> {
 
     Optional<CartItems> findByCartsAndMenus(Carts carts, Menus menus);
 
-    //장바구니 초기화
     void deleteAllByCarts(Carts carts);
+
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImpl.java
@@ -7,7 +7,6 @@ import com.delivery.igo.igo_delivery.api.order.repository.OrderItemsRepository;
 import com.delivery.igo.igo_delivery.api.order.repository.OrderRepository;
 import com.delivery.igo.igo_delivery.api.review.dto.ReviewRequestDto;
 import com.delivery.igo.igo_delivery.api.review.dto.ReviewResponseDto;
-import com.delivery.igo.igo_delivery.api.review.dto.ReviewUpdateRequestDto;
 import com.delivery.igo.igo_delivery.api.review.entity.Reviews;
 import com.delivery.igo.igo_delivery.api.review.repository.ReviewRepository;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;

--- a/src/main/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImpl.java
@@ -57,7 +57,7 @@ public class ReviewServiceImpl implements ReviewService {
         // DB에서 주문 조회 + 본인 확인 + 주문 상태 검증
         Orders findOrder = orderRepository.findById(requestDto.getOrdersId())
                 .orElseThrow(() -> new GlobalException(ErrorCode.ORDER_NOT_FOUND));
-        findOrder.getUsers().validateAccess(authUser);// 주문의 usersId와 authUser의 usersId 가 같은지 검증 (본인이 남긴 주문에 리뷰를 남기는 상황인지 검증)
+        findOrder.getUsers().validateAccess(authUser.getId());// 주문의 usersId와 authUser의 usersId 가 같은지 검증 (본인이 남긴 주문에 리뷰를 남기는 상황인지 검증)
         if (!Objects.equals(findOrder.getOrderStatus(), OrderStatus.COMPLETE)) { // 주문 완료인 경우에만 리뷰를 남길 수 있음
             throw new GlobalException(ErrorCode.REVIEW_ORDER_INVALID);
         }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
@@ -1,7 +1,6 @@
 package com.delivery.igo.igo_delivery.api.user.entity;
 
 import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
-import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.entity.BaseEntity;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.exception.GlobalException;
@@ -12,7 +11,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 @Entity
 @NoArgsConstructor
@@ -80,8 +78,8 @@ public class Users extends BaseEntity {
     }
 
     // 접근 권한 검증, 로그인한 유저의 id와 id가 다르면 예외 발생
-    public void validateAccess(AuthUser authUser) {
-        if (!Objects.equals(authUser.getId(), id)) {
+    public void validateAccess(long userId) {
+        if (userId != id) {
             throw new GlobalException(ErrorCode.FORBIDDEN);
         }
     }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
@@ -1,7 +1,6 @@
 package com.delivery.igo.igo_delivery.api.user.entity;
 
 import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
-import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.entity.BaseEntity;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
@@ -54,12 +53,12 @@ public class Users extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus userStatus;
 
-    // 내 정보 수정 -> 멀티 모듈 프로젝트?일때 문제 발생가능성
-    public void updateBy(UpdateUserRequestDto requestDto) {
-        this.nickname = requestDto.getNickname();
-        this.phoneNumber = requestDto.getPhoneNumber();
-        this.address = requestDto.getAddress();
-        this.userRole = requestDto.getRole();
+    // 내 정보 수정 -> 멀티 모듈 프로젝트일때 문제 발생가능성 있음
+    public void updateBy(String nickname, String phoneNumber, String address, UserRole role) {
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+        this.userRole = role;
     }
 
     // 비밀번호 수정
@@ -115,4 +114,5 @@ public class Users extends BaseEntity {
                 .build();
 
     }
+
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
@@ -1,6 +1,5 @@
 package com.delivery.igo.igo_delivery.api.user.entity;
 
-import com.delivery.igo.igo_delivery.api.auth.dto.request.SignupRequestDto;
 import com.delivery.igo.igo_delivery.common.entity.BaseEntity;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.exception.GlobalException;

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/entity/Users.java
@@ -98,19 +98,4 @@ public class Users extends BaseEntity {
         }
     }
 
-    public static Users of(SignupRequestDto signupRequestDto, String encodedPassword) {
-        UserRole userRole = UserRole.of(signupRequestDto.getUserRole());
-
-        return Users.builder()
-                .email(signupRequestDto.getEmail())
-                .nickname(signupRequestDto.getNickname())
-                .phoneNumber(signupRequestDto.getPhoneNumber())
-                .password(encodedPassword)
-                .address(signupRequestDto.getAddress())
-                .userRole(userRole)
-                .userStatus(UserStatus.LIVE)
-                .build();
-
-    }
-
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -1,5 +1,8 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
+import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
+import com.delivery.igo.igo_delivery.api.cart.repository.CartItemsRepository;
+import com.delivery.igo.igo_delivery.api.cart.repository.CartRepository;
 import com.delivery.igo.igo_delivery.api.user.dto.request.DeleteUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
@@ -21,6 +24,8 @@ import java.util.Objects;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final CartRepository cartRepository;
+    private final CartItemsRepository cartItemsRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Override
@@ -72,7 +77,11 @@ public class UserServiceImpl implements UserService {
         if (!passwordEncoder.matches(requestDto.getPassword(), users.getPassword())) {
             throw new GlobalException(ErrorCode.PASSWORD_NOT_MATCHED);
         }
+        Carts carts = cartRepository.findByUsers(users)
+                .orElseThrow(() -> new GlobalException(ErrorCode.CART_ITEM_NOT_FOUND));
 
+        cartItemsRepository.deleteAllByCarts(carts);
+        cartRepository.delete(carts);
         users.delete();
     }
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -80,7 +80,7 @@ public class UserServiceImpl implements UserService {
     private Users getUserWithAccessCheck(Long id, AuthUser authUser) {
         // 유저가 없으면 예외
         Users users = userRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
-        users.validateAccess(authUser); // 로그인한 본인인지 검증
+        users.validateAccess(authUser.getId()); // 로그인한 본인인지 검증
         users.validateDelete();         // 삭제 되었는지 검증
         return users;
     }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -41,7 +41,7 @@ public class UserServiceImpl implements UserService {
             throw new GlobalException(ErrorCode.USER_EXIST_NICKNAME);
         }
 
-        users.updateBy(requestDto);
+        users.updateBy(requestDto.getNickname(), requestDto.getPhoneNumber(), requestDto.getAddress(), requestDto.getRole());
 
         return UserResponseDto.from(users);
     }

--- a/src/test/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImplUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/auth/service/AuthServiceImplUnitTest.java
@@ -77,7 +77,16 @@ class AuthServiceImplUnitTest {
     @Test
     void 로그인이_성공하면_토큰이_발급됨() {
         // given
-        Users mockUser = Users.of(SIGNUP_REQUEST_DTO, "encodedPassword");
+        Users mockUser = Users.builder()
+                .email(SIGNUP_REQUEST_DTO.getEmail())
+                .nickname(SIGNUP_REQUEST_DTO.getNickname())
+                .phoneNumber(SIGNUP_REQUEST_DTO.getPhoneNumber())
+                .password("encodedPassword")
+                .address(SIGNUP_REQUEST_DTO.getAddress())
+                .userRole(UserRole.of(SIGNUP_REQUEST_DTO.getUserRole()))
+                .userStatus(UserStatus.LIVE)
+                .build();
+
         given(userRepository.findByEmailAndUserStatus(SIGNUP_REQUEST_DTO.getEmail(), UserStatus.LIVE)).willReturn(Optional.of(mockUser));
         given(passwordEncoder.matches(LOGIN_REQUEST_DTO.getPassword(), mockUser.getPassword())).willReturn(true);
         given(jwtUtil.createToken(mockUser)).willReturn("mockToken");
@@ -106,7 +115,15 @@ class AuthServiceImplUnitTest {
     @Test
     void 로그인시_비밀번호가_일지하지않으면_예외발생_에러코드_LOGIN_FALIED() {
         // given
-        Users mockUser = Users.of(SIGNUP_REQUEST_DTO, "encodedPassword");
+        Users mockUser = Users.builder()
+                .email(SIGNUP_REQUEST_DTO.getEmail())
+                .nickname(SIGNUP_REQUEST_DTO.getNickname())
+                .phoneNumber(SIGNUP_REQUEST_DTO.getPhoneNumber())
+                .password("encodedPassword")
+                .address(SIGNUP_REQUEST_DTO.getAddress())
+                .userRole(UserRole.of(SIGNUP_REQUEST_DTO.getUserRole()))
+                .userStatus(UserStatus.LIVE)
+                .build();
 
         given(userRepository.findByEmailAndUserStatus(LOGIN_REQUEST_DTO.getEmail(), UserStatus.LIVE)).willReturn(Optional.of(mockUser));
         given(passwordEncoder.matches(LOGIN_REQUEST_DTO.getPassword(), mockUser.getPassword())).willReturn(false);

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/entity/UsersUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/entity/UsersUnitTest.java
@@ -16,7 +16,7 @@ class UsersUnitTest {
         Users user = Users.builder().userStatus(UserStatus.INACTIVE).build();
 
         // when & then
-        GlobalException exception = assertThrows(GlobalException.class, () -> user.validateDelete());
+        GlobalException exception = assertThrows(GlobalException.class, user::validateDelete);
         assertEquals(ErrorCode.DELETED_USER, exception.getErrorCode());
     }
 

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/entity/UsersUnitTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/entity/UsersUnitTest.java
@@ -27,7 +27,7 @@ class UsersUnitTest {
         AuthUser authUser = new AuthUser(2L, null, null, null);
 
         // when * then
-        GlobalException exception = assertThrows(GlobalException.class, () -> user.validateAccess(authUser));
+        GlobalException exception = assertThrows(GlobalException.class, () -> user.validateAccess(authUser.getId()));
         assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
     }
 }

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplIntegrationTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplIntegrationTest.java
@@ -1,6 +1,10 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
 import com.delivery.igo.igo_delivery.IgoDeliveryApplication;
+import com.delivery.igo.igo_delivery.api.auth.service.AuthService;
+import com.delivery.igo.igo_delivery.api.auth.service.AuthServiceImpl;
+import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
+import com.delivery.igo.igo_delivery.api.cart.repository.CartRepository;
 import com.delivery.igo.igo_delivery.api.user.dto.request.DeleteUserRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdatePasswordRequestDto;
 import com.delivery.igo.igo_delivery.api.user.dto.request.UpdateUserRequestDto;
@@ -31,6 +35,9 @@ class UserServiceImplIntegrationTest {
     UserRepository userRepository;
 
     @Autowired
+    CartRepository cartRepository;
+
+    @Autowired
     UserServiceImpl userService;
 
     @Autowired
@@ -54,6 +61,9 @@ class UserServiceImplIntegrationTest {
         userRepository.save(user);
 
         authUser = new AuthUser(user.getId(), "email@naver.com", "정상유저", UserRole.OWNER);
+
+        Carts carts = new Carts(user);
+        cartRepository.save(carts);
     }
 
     @Test
@@ -107,7 +117,7 @@ class UserServiceImplIntegrationTest {
     }
 
     @Test
-    void 비밀번호_수정이_정상적으로_성공() {
+    void 회원삭제가_정상적으로_성공() {
         // given
         DeleteUserRequestDto requestDto = new DeleteUserRequestDto("oldPassword123!@#");
 
@@ -119,7 +129,7 @@ class UserServiceImplIntegrationTest {
     }
 
     @Test
-    void 비밀번호_수정이_실패하면_트랜잭션롤백() {
+    void 회원_삭제가_실패하면_트랜잭션롤백() {
         // given
         DeleteUserRequestDto requestDto = new DeleteUserRequestDto("oldPassword123!@#");
         AuthUser otherAuthUser = new AuthUser(999L, "other@naver.com", "다른유저", UserRole.OWNER);
@@ -129,4 +139,5 @@ class UserServiceImplIntegrationTest {
         assertEquals(UserStatus.LIVE, user.getUserStatus());
         assertNotEquals(UserStatus.INACTIVE, user.getUserStatus());
     }
+
 }

--- a/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplIntegrationTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImplIntegrationTest.java
@@ -1,8 +1,6 @@
 package com.delivery.igo.igo_delivery.api.user.service;
 
 import com.delivery.igo.igo_delivery.IgoDeliveryApplication;
-import com.delivery.igo.igo_delivery.api.auth.service.AuthService;
-import com.delivery.igo.igo_delivery.api.auth.service.AuthServiceImpl;
 import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
 import com.delivery.igo.igo_delivery.api.cart.repository.CartRepository;
 import com.delivery.igo.igo_delivery.api.user.dto.request.DeleteUserRequestDto;
@@ -24,7 +22,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(classes = IgoDeliveryApplication.class)
 @Transactional


### PR DESCRIPTION
## Description
1. 회원탈퇴 API 수정
    - 회원 탈퇴 시 해당 회원과 연관있는 장바구니를 조회하여 장바구니가 담고있는 장바구니 아이템을 삭제하고 장바구니도 삭제하도록 로직을 수정
    - 장바구니 조회시 장바구니를 못찾으면 예외를 던짐(비즈니스 로직상 없을수가 없긴함)

2. Users Entity 리팩토링 - web과 관련된 Dto의존성 제거
    - updateBy()에서 updateUserRequestDto 의존성 제거
    - validateAccess()에서 AuthUser 의존성 제거
    - Users.of() 메서드 삭제

## Changes
1. 회원 탈퇴 API 수정
    - UserServiceImpl - deleteUser() 메서드 수정

2. updateBy() 수정
    - 서비스에서 requestDto를 모두 까서 넘기도록 변경

3. validateAccess() 수정
    - 서비스에서 AuthUser.getId()를 넘기도록 수정
    - 리뷰서비스에서 해당 로직을 사용하기 때문에 함께 수정하였음

4. Users.of() 메서드 삭제
    - 회원 가입할 때 이를 사용하기 때문에 AuthServiceImpl의 singup()메서드 수정
    - 서비스 로직에서 requestDto의 입력된 패스워드를 꺼내서 인코딩하고, 입력된 UserRole을 꺼내서 UserRole 객체로 변환
    - 인코딩된 패스워드와 UserRole, requestDto를 인자로 하여 새로운 유저를 빌드하는 코드를 private 메서드로 제공
    - 유저를 생성하는 코드를 단순히 파라미터들을 통해 조립만 하기 때문에 메서드 명으로 판단이 될 것이라고 생각하여 private메서드로 뺐음


## Screenshots
- 화면이 추가되거나 변경된 경우 스크린샷을 첨부해주세요. (없어도 무관)
- 상태의 변경이나 플로우 같은 동적인 동작은 영상을 촬영하여 첨부해주세요. (없어도 무관)

## Ref
1. 회원 생성시 생성된 장바구니
![image](https://github.com/user-attachments/assets/c14bd54d-fe03-42a2-bdd1-b1cd7d93786a)

2. 회원틀 탈퇴하면 장바구니가 삭제됨
![image](https://github.com/user-attachments/assets/24768b3a-ad4d-4cf4-aa18-71e55444c42f)
![image](https://github.com/user-attachments/assets/74286c1b-23c0-4eb0-8c1e-ada9e59c0d91)
![image](https://github.com/user-attachments/assets/7ebd0305-750d-4f0e-bfdb-3fa6cfbea1cd)

3. 기존 User, Auth 테스트 모두 통과
![image](https://github.com/user-attachments/assets/c519c3c6-3729-4f55-8fb9-3d2057376d1c)
![image](https://github.com/user-attachments/assets/b13194a7-48b0-4d8e-9343-9027ac90b545)


