### PR TITLE
[Store] 매장 전체 조회 기능 구현

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImpl.java
@@ -7,7 +7,6 @@ import com.delivery.igo.igo_delivery.api.order.repository.OrderItemsRepository;
 import com.delivery.igo.igo_delivery.api.order.repository.OrderRepository;
 import com.delivery.igo.igo_delivery.api.review.dto.ReviewRequestDto;
 import com.delivery.igo.igo_delivery.api.review.dto.ReviewResponseDto;
-import com.delivery.igo.igo_delivery.api.review.dto.ReviewUpdateRequestDto;
 import com.delivery.igo.igo_delivery.api.review.entity.Reviews;
 import com.delivery.igo.igo_delivery.api.review.repository.ReviewRepository;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
@@ -6,17 +6,15 @@ import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
 import com.delivery.igo.igo_delivery.api.store.service.StoreService;
 import com.delivery.igo.igo_delivery.common.annotation.Auth;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.dto.PageResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,22 +35,16 @@ public class StoreController {
 
     // 매장 전체 조회
     @GetMapping
-    public ResponseEntity<Map<String, Object>> getStores(
+    public ResponseEntity<PageResponseDto<StoreListResponseDto>> getStores(
             @RequestParam(name = "storeName", defaultValue = "") String storeName,
-            @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "10") int size
+            @PageableDefault(page = 0, size = 10) Pageable pageable
     ) {
-        Pageable pageable = PageRequest.of(page, size);
-
+        // 매장 목록을 페이지네이션 조회
         Page<StoreListResponseDto> storePage = storeService.getStores(storeName, pageable);
 
-        Map<String, Object> result = new LinkedHashMap<>();
-        result.put("stores", storePage.getContent());
-        result.put("totalElements", storePage.getTotalElements());
-        result.put("page", storePage.getNumber());
-        result.put("size", storePage.getSize());
-        result.put("totalPages", storePage.getTotalPages());
+        // 조회 결과를 PageResponseDto 형태로 변환
+        PageResponseDto<StoreListResponseDto> response = PageResponseDto.from(storePage);
 
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
@@ -9,8 +9,8 @@ import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -39,8 +39,11 @@ public class StoreController {
     @GetMapping
     public ResponseEntity<Map<String, Object>> getStores(
             @RequestParam(name = "storeName", defaultValue = "") String storeName,
-            @PageableDefault(size = 10) Pageable pageable
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
     ) {
+        Pageable pageable = PageRequest.of(page, size);
+
         Page<StoreListResponseDto> storePage = storeService.getStores(storeName, pageable);
 
         Map<String, Object> result = new LinkedHashMap<>();

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
@@ -1,5 +1,6 @@
 package com.delivery.igo.igo_delivery.api.store.controller;
 
+import com.delivery.igo.igo_delivery.api.store.dto.StoreListResponseDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
 import com.delivery.igo.igo_delivery.api.store.service.StoreService;
@@ -7,12 +8,15 @@ import com.delivery.igo.igo_delivery.common.annotation.Auth;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,5 +33,22 @@ public class StoreController {
     ) {
         StoreResponseDto response = storeService.createStore(requestDto, loginUser.getId());
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> getStores(
+            @RequestParam(defaultValue = "") String storeName,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Page<StoreListResponseDto> storePage = storeService.getStores(storeName, pageable);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("stores", storePage.getContent());
+        result.put("totalElements", storePage.getTotalElements());
+        result.put("page", storePage.getNumber());
+        result.put("size", storePage.getSize());
+        result.put("totalPages", storePage.getTotalPages());
+
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
@@ -35,9 +35,10 @@ public class StoreController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    // 매장 전체 조회
     @GetMapping
     public ResponseEntity<Map<String, Object>> getStores(
-            @RequestParam(defaultValue = "") String storeName,
+            @RequestParam(name = "storeName", defaultValue = "") String storeName,
             @PageableDefault(size = 10) Pageable pageable
     ) {
         Page<StoreListResponseDto> storePage = storeService.getStores(storeName, pageable);

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreListResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreListResponseDto.java
@@ -5,20 +5,30 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class StoreListResponseDto {
 
-    private Long id;
-    private String storeName;
-    private String storeAddress;
+    private Long id;                    // 매장 ID
+    private String storeName;           // 매장 이름
+    private Integer minOrderPrice;      // 최소 주문 금액
+    private Integer reviewCount;        // 리뷰 수
+    private Double avgRating;           // 평균 별점
+    private LocalDateTime createdAt;    // 생성 일시
+    private LocalDateTime modifiedAt;   // 수정 일시
 
     public static StoreListResponseDto from(Stores store) {
         return new StoreListResponseDto(
                 store.getId(),
                 store.getStoreName(),
-                store.getStoreAddress()
+                store.getMinOrderPrice(),
+                store.getReviewCount(),
+                store.getAvgRating(),
+                store.getCreatedAt(),
+                store.getModifiedAt()
         );
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreListResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreListResponseDto.java
@@ -1,0 +1,24 @@
+package com.delivery.igo.igo_delivery.api.store.dto;
+
+import com.delivery.igo.igo_delivery.api.store.entity.Stores;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreListResponseDto {
+
+    private Long id;
+    private String storeName;
+    private String storeAddress;
+
+    public static StoreListResponseDto from(Stores store) {
+        return new StoreListResponseDto(
+                store.getId(),
+                store.getStoreName(),
+                store.getStoreAddress()
+        );
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/entity/StoreStatus.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/entity/StoreStatus.java
@@ -2,5 +2,7 @@ package com.delivery.igo.igo_delivery.api.store.entity;
 
 public enum StoreStatus {
     LIVE,
+
+    OPEN,
     CLOSED
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/repository/StoreRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/repository/StoreRepository.java
@@ -3,8 +3,12 @@ package com.delivery.igo.igo_delivery.api.store.repository;
 import com.delivery.igo.igo_delivery.api.store.entity.StoreStatus;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Stores, Long> {
     long countByUsersAndStoreStatusIsNot(Users user, StoreStatus status);
+
+    Page<Stores> findByStoreNameContainingIgnoreCaseAndDeletedAtIsNull(String name, Pageable pageable);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreService.java
@@ -14,5 +14,5 @@ public interface StoreService {
     StoreResponseDto createStore(StoreRequestDto requestDto, Long userId);
 
     // 매장 전체 조회
-    Page<StoreListResponseDto> getStores(String name, Pageable pageable);
+    Page<StoreListResponseDto> getStores(String storeName, Pageable pageable);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreService.java
@@ -1,12 +1,18 @@
 package com.delivery.igo.igo_delivery.api.store.service;
 
+import com.delivery.igo.igo_delivery.api.store.dto.StoreListResponseDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
 import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface StoreService {
 
     // 매장 생성
     @Transactional
     StoreResponseDto createStore(StoreRequestDto requestDto, Long userId);
+
+    // 매장 전체 조회
+    Page<StoreListResponseDto> getStores(String name, Pageable pageable);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -1,5 +1,6 @@
 package com.delivery.igo.igo_delivery.api.store.service;
 
+import com.delivery.igo.igo_delivery.api.store.dto.StoreListResponseDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
 import com.delivery.igo.igo_delivery.api.store.entity.StoreStatus;
@@ -11,6 +12,8 @@ import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.exception.GlobalException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -41,5 +44,12 @@ public class StoreServiceImpl implements StoreService{
 
         // 저장된 엔티티를 DTO로 변환하여 반환
         return StoreResponseDto.from(store);
+    }
+
+    // 매장 전체 조회
+    @Override
+    public Page<StoreListResponseDto> getStores(String name, Pageable pageable) {
+        Page<Stores> stores = storeRepository.findByStoreNameContainingIgnoreCaseAndDeletedAtIsNull(name, pageable);
+        return stores.map(StoreListResponseDto::from);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class StoreServiceImpl implements StoreService{
+public class StoreServiceImpl implements StoreService {
 
     private final StoreRepository storeRepository;
     private final UserRepository userRepository;
@@ -49,6 +49,23 @@ public class StoreServiceImpl implements StoreService{
     // 매장 전체 조회
     @Override
     public Page<StoreListResponseDto> getStores(String storeName, Pageable pageable) {
+        int page = pageable.getPageNumber();
+        int size = pageable.getPageSize();
+
+        // 잘못된 페이지 번호인 경우
+        if (page < 0) {
+            throw new GlobalException(ErrorCode.INVALID_PAGE_PARAMETER);
+        }
+
+        // 잘못된 페이지 크기인 경우
+        if (size <= 0) {
+            throw new GlobalException(ErrorCode.INVALID_SIZE_TOO_SMALL);
+        }
+
+        // 페이지 크기가 너무 큰 경우
+        if (size > 100) {
+            throw new GlobalException(ErrorCode.INVALID_SIZE_TOO_LARGE);
+        }
 
         // storeName이 빈 문자열일 때 모든 매장을 조회
         // storeName이 비어있지 않으면 해당 이름을 포함하는 매장만 조회

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -27,7 +27,7 @@ public class StoreServiceImpl implements StoreService {
     private static final int DEFAULT_PAGE_NUMBER = 0;
     private static final int MIN_PAGE_SIZE = 1;
     private static final int DEFAULT_PAGE_SIZE = 10;
-    private static final int MAX_PAGE_SIZE = 500;
+    private static final int MAX_PAGE_SIZE = 50;
 
     // 매장 생성
     @Transactional

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -15,9 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
-
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Service
 @RequiredArgsConstructor
@@ -49,28 +46,32 @@ public class StoreServiceImpl implements StoreService {
         return StoreResponseDto.from(store);
     }
 
+    // 매장 전체 조회
     @Override
     public Page<StoreListResponseDto> getStores(String storeName, Pageable pageable) {
         int page = pageable.getPageNumber();
         int size = pageable.getPageSize();
 
-        // 페이지 번호 검증
+        // 잘못된 페이지 번호인 경우
         if (page < 0) {
-            throw new ResponseStatusException(BAD_REQUEST, "페이지 번호는 0 이상이어야 합니다.");
+            throw new GlobalException(ErrorCode.INVALID_PAGE_PARAMETER);
         }
 
-        // 사이즈 크기 검증
+        // 잘못된 사이즈 크기인 경우
         if (size <= 0) {
-            throw new ResponseStatusException(BAD_REQUEST, "사이즈 크기는 1 이상이어야 합니다.");
+            throw new GlobalException(ErrorCode.INVALID_SIZE_TOO_SMALL);
         }
 
-        // 사이즈 크기 검증
+        // 사이즈 크기가 너무 큰 경우
         if (size > 100) {
-            throw new ResponseStatusException(BAD_REQUEST, "사이즈 크기는 100 이하로 요청해야 합니다.");
+            throw new GlobalException(ErrorCode.INVALID_SIZE_TOO_LARGE);
         }
 
+        // storeName이 빈 문자열일 때 모든 매장을 조회
+        // storeName이 비어있지 않으면 해당 이름을 포함하는 매장만 조회
         Page<Stores> stores = storeRepository.findByStoreNameContainingIgnoreCaseAndDeletedAtIsNull(storeName, pageable);
 
+        // 조회된 매장들을 StoreListResponseDto로 변환하여 반환
         return stores.map(StoreListResponseDto::from);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -57,12 +57,12 @@ public class StoreServiceImpl implements StoreService {
             throw new GlobalException(ErrorCode.INVALID_PAGE_PARAMETER);
         }
 
-        // 잘못된 페이지 크기인 경우
+        // 잘못된 사이즈 크기인 경우
         if (size <= 0) {
             throw new GlobalException(ErrorCode.INVALID_SIZE_TOO_SMALL);
         }
 
-        // 페이지 크기가 너무 큰 경우
+        // 사이즈 크기가 너무 큰 경우
         if (size > 100) {
             throw new GlobalException(ErrorCode.INVALID_SIZE_TOO_LARGE);
         }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -39,17 +39,22 @@ public class StoreServiceImpl implements StoreService{
             throw new GlobalException(ErrorCode.MAX_STORE_LIMIT);
         }
 
-        // DTO -> 엔티티 변환 후 저장
+        // DTO -> entity 변환 후 저장
         Stores store = storeRepository.save(requestDto.toEntity(owner));
 
-        // 저장된 엔티티를 DTO로 변환하여 반환
+        // 저장된 entity를 DTO로 변환하여 반환
         return StoreResponseDto.from(store);
     }
 
     // 매장 전체 조회
     @Override
-    public Page<StoreListResponseDto> getStores(String name, Pageable pageable) {
-        Page<Stores> stores = storeRepository.findByStoreNameContainingIgnoreCaseAndDeletedAtIsNull(name, pageable);
+    public Page<StoreListResponseDto> getStores(String storeName, Pageable pageable) {
+
+        // storeName이 빈 문자열일 때 모든 매장을 조회
+        // storeName이 비어있지 않으면 해당 이름을 포함하는 매장만 조회
+        Page<Stores> stores = storeRepository.findByStoreNameContainingIgnoreCaseAndDeletedAtIsNull(storeName, pageable);
+
+        // 조회된 매장들을 StoreListResponseDto로 변환하여 반환
         return stores.map(StoreListResponseDto::from);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -15,6 +15,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Service
 @RequiredArgsConstructor
@@ -46,32 +49,28 @@ public class StoreServiceImpl implements StoreService {
         return StoreResponseDto.from(store);
     }
 
-    // 매장 전체 조회
     @Override
     public Page<StoreListResponseDto> getStores(String storeName, Pageable pageable) {
         int page = pageable.getPageNumber();
         int size = pageable.getPageSize();
 
-        // 잘못된 페이지 번호인 경우
+        // 페이지 번호 검증
         if (page < 0) {
-            throw new GlobalException(ErrorCode.INVALID_PAGE_PARAMETER);
+            throw new ResponseStatusException(BAD_REQUEST, "페이지 번호는 0 이상이어야 합니다.");
         }
 
-        // 잘못된 사이즈 크기인 경우
+        // 사이즈 크기 검증
         if (size <= 0) {
-            throw new GlobalException(ErrorCode.INVALID_SIZE_TOO_SMALL);
+            throw new ResponseStatusException(BAD_REQUEST, "사이즈 크기는 1 이상이어야 합니다.");
         }
 
-        // 사이즈 크기가 너무 큰 경우
+        // 사이즈 크기 검증
         if (size > 100) {
-            throw new GlobalException(ErrorCode.INVALID_SIZE_TOO_LARGE);
+            throw new ResponseStatusException(BAD_REQUEST, "사이즈 크기는 100 이하로 요청해야 합니다.");
         }
 
-        // storeName이 빈 문자열일 때 모든 매장을 조회
-        // storeName이 비어있지 않으면 해당 이름을 포함하는 매장만 조회
         Page<Stores> stores = storeRepository.findByStoreNameContainingIgnoreCaseAndDeletedAtIsNull(storeName, pageable);
 
-        // 조회된 매장들을 StoreListResponseDto로 변환하여 반환
         return stores.map(StoreListResponseDto::from);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/dto/PageResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/dto/PageResponseDto.java
@@ -1,0 +1,30 @@
+package com.delivery.igo.igo_delivery.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PageResponseDto<T> {
+
+    private List<T> content;
+    private long totalElements;
+    private int page;
+    private int size;
+    private int totalPages;
+
+    public static <T> PageResponseDto<T> from(Page<T> page) {
+        return new PageResponseDto<>(
+                page.getContent(),
+                page.getTotalElements(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalPages()
+        );
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
@@ -56,16 +56,17 @@ public enum ErrorCode {
     ROLE_CONSUMER_FORBIDDEN(HttpStatus.UNAUTHORIZED, "주문 고객이 아닙니다."),
     ROLE_OWNER_FORBIDDEN(HttpStatus.UNAUTHORIZED, "매장 사장님이 아닙니다."),
 
-    // Store
-    NOT_OWNER(HttpStatus.FORBIDDEN, "사장님 권한이 아닙니다."),
-
     // CartItem
     CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다."),
 
     // Store
+    NOT_OWNER(HttpStatus.FORBIDDEN, "사장님 권한이 아닙니다."),
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다."),
     STORE_OWNER_MISMATCH(HttpStatus.FORBIDDEN, "해당 가게의 사장님만 접근할 수 있습니다."),
     MAX_STORE_LIMIT(HttpStatus.BAD_REQUEST, "매장은 최대 3개까지 생성할 수 있습니다."),
+    INVALID_PAGE_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 페이지 번호입니다."),
+    INVALID_SIZE_TOO_SMALL(HttpStatus.BAD_REQUEST, "페이지 크기는 1 이상이어야 합니다."),
+    INVALID_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "페이지 크기는 100 이하여야 합니다."),
 
     // Menu
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "메뉴를 찾을 수 없습니다."),

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
@@ -64,9 +64,6 @@ public enum ErrorCode {
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다."),
     STORE_OWNER_MISMATCH(HttpStatus.FORBIDDEN, "해당 가게의 사장님만 접근할 수 있습니다."),
     MAX_STORE_LIMIT(HttpStatus.BAD_REQUEST, "매장은 최대 3개까지 생성할 수 있습니다."),
-    INVALID_PAGE_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 페이지 번호입니다."),
-    INVALID_SIZE_TOO_SMALL(HttpStatus.BAD_REQUEST, "사이즈 크기는 1 이상이어야 합니다."),
-    INVALID_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "사이즈 크기는 100 이하여야 합니다."),
 
     // Menu
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "메뉴를 찾을 수 없습니다."),

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
@@ -65,8 +65,8 @@ public enum ErrorCode {
     STORE_OWNER_MISMATCH(HttpStatus.FORBIDDEN, "해당 가게의 사장님만 접근할 수 있습니다."),
     MAX_STORE_LIMIT(HttpStatus.BAD_REQUEST, "매장은 최대 3개까지 생성할 수 있습니다."),
     INVALID_PAGE_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 페이지 번호입니다."),
-    INVALID_SIZE_TOO_SMALL(HttpStatus.BAD_REQUEST, "페이지 크기는 1 이상이어야 합니다."),
-    INVALID_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "페이지 크기는 100 이하여야 합니다."),
+    INVALID_SIZE_TOO_SMALL(HttpStatus.BAD_REQUEST, "사이즈 크기는 1 이상이어야 합니다."),
+    INVALID_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "사이즈 크기는 100 이하여야 합니다."),
 
     // Menu
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "메뉴를 찾을 수 없습니다."),

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalExceptionHandler.java
@@ -83,22 +83,4 @@ public class GlobalExceptionHandler {
                 request.getRequestURI());
         return new ResponseEntity<>(errorDto, ErrorCode.VALID_BAD_REQUEST.getHttpStatus());
     }
-
-    /**
-     * 잘못된 요청 등을 GlobalException으로 던졌을 때
-     * 우리가 정의한 에러 코드와 메시지로 에러 응답을 내려주기 위한 처리
-     */
-    @ExceptionHandler(GlobalException.class)
-    public ResponseEntity<ErrorDto> handleGlobalException(GlobalException e, HttpServletRequest request) {
-        log.error("[handleGlobalException] ex: ", e);
-        ErrorCode errorCode = e.getErrorCode();
-
-        ErrorDto errorDto = new ErrorDto(
-                errorCode.getHttpStatus().value(),
-                errorCode.getMessage(),
-                LocalDateTime.now(),
-                request.getRequestURI());
-
-        return new ResponseEntity<>(errorDto, errorCode.getHttpStatus());
-    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/GlobalExceptionHandler.java
@@ -84,5 +84,21 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorDto, ErrorCode.VALID_BAD_REQUEST.getHttpStatus());
     }
 
+    /**
+     * 잘못된 요청 등을 GlobalException으로 던졌을 때
+     * 우리가 정의한 에러 코드와 메시지로 에러 응답을 내려주기 위한 처리
+     */
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<ErrorDto> handleGlobalException(GlobalException e, HttpServletRequest request) {
+        log.error("[handleGlobalException] ex: ", e);
+        ErrorCode errorCode = e.getErrorCode();
 
+        ErrorDto errorDto = new ErrorDto(
+                errorCode.getHttpStatus().value(),
+                errorCode.getMessage(),
+                LocalDateTime.now(),
+                request.getRequestURI());
+
+        return new ResponseEntity<>(errorDto, errorCode.getHttpStatus());
+    }
 }

--- a/src/test/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceTest.java
@@ -1,19 +1,27 @@
 package com.delivery.igo.igo_delivery.api.store.service;
 
+import com.delivery.igo.igo_delivery.api.store.dto.StoreListResponseDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
 import com.delivery.igo.igo_delivery.api.store.entity.StoreStatus;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;
 import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
 import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
 
 import java.sql.Time;
 import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,6 +33,9 @@ public class StoreServiceTest {
 
     @Mock
     private StoreRepository storeRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @InjectMocks
     private StoreServiceImpl storeService;
@@ -49,11 +60,15 @@ public class StoreServiceTest {
                 10000
         );
 
+        // userRepository.findById() 호출 시 owner 반환
+        when(userRepository.findById(owner.getId()))
+                .thenReturn(Optional.of(owner));
+
         // 이미 등록된 매장이 2개라고 가정
         when(storeRepository.countByUsersAndStoreStatusIsNot(owner, StoreStatus.CLOSED))
                 .thenReturn(2L);
 
-        // storeRepository.save() 호출 시, 실제 매장 엔티티 리턴하도록 설정
+        // storeRepository.save() 호출 시, 실제 매장 엔티티 반환
         Stores store = Stores.builder()
                 .users(owner)
                 .storeName("초코라떼가제일좋아")
@@ -73,6 +88,82 @@ public class StoreServiceTest {
         // then
         assertThat(response).isNotNull();
         assertThat(response.getStoreName()).isEqualTo("초코라떼가제일좋아");
+
+        // storeRepository.save()가 호출되었는지 검증
         verify(storeRepository).save(any(Stores.class));
+    }
+
+    @Test
+    void 매장_전체_조회_검색어_있음() {
+
+        // given
+        Users owner = Users.builder()
+                .id(1L)
+                .nickname("초코라떼")
+                .build();
+
+        Stores store = Stores.builder()
+                .id(1L)
+                .users(owner)
+                .storeName("초코라떼가제일좋아")
+                .storeAddress("인천시 미추홀구")
+                .storePhoneNumber("010-8282-8282")
+                .openTime(Time.valueOf(LocalTime.of(8, 0)))
+                .endTime(Time.valueOf(LocalTime.of(22, 0)))
+                .minOrderPrice(10000)
+                .storeStatus(StoreStatus.OPEN)
+                .build();
+
+        PageRequest pageable = PageRequest.of(0, 10);
+        Page<Stores> storePage = new PageImpl<>(List.of(store), pageable, 1);
+
+        when(storeRepository.findByStoreNameContainingIgnoreCaseAndDeletedAtIsNull("초코라떼", pageable))
+                .thenReturn(storePage);
+
+        // when
+        Page<StoreListResponseDto> result = storeService.getStores("초코라떼", pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getStoreName()).isEqualTo("초코라떼가제일좋아");
+    }
+
+    @Test
+    void 매장_전체_조회_검색어_없음() {
+        // given
+        Stores store1 = Stores.builder().id(1L).storeName("초코라떼").minOrderPrice(10000).build();
+        Stores store2 = Stores.builder().id(2L).storeName("설빙").minOrderPrice(19000).build();
+
+        PageRequest pageable = PageRequest.of(0, 10);
+        Page<Stores> storePage = new PageImpl<>(List.of(store1, store2), pageable, 2);
+
+        when(storeRepository.findByStoreNameContainingIgnoreCaseAndDeletedAtIsNull("", pageable))
+                .thenReturn(storePage);
+
+        // when
+        Page<StoreListResponseDto> result = storeService.getStores("", pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent().get(0).getStoreName()).isEqualTo("초코라떼");
+        assertThat(result.getContent().get(1).getStoreName()).isEqualTo("설빙");
+    }
+
+    @Test
+    void 매장_전체_조회_검색어_매장_없음() {
+        // given
+        PageRequest pageable = PageRequest.of(0, 10);
+        Page<Stores> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+        when(storeRepository.findByStoreNameContainingIgnoreCaseAndDeletedAtIsNull("황금올리브", pageable))
+                .thenReturn(emptyPage);
+
+        // when
+        Page<StoreListResponseDto> result = storeService.getStores("황금올리브", pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isZero();
+        assertThat(result.getContent()).isEmpty();
     }
 }


### PR DESCRIPTION
### Description  
- 매장 전체 목록 조회 기능을 구현했습니다.  
- 가게 이름 검색 기능(부분 일치)과 페이지네이션(page, size) 기능을 적용했습니다.  
- 매장이 없는 경우에도 404가 아닌 빈 배열과 200 OK를 반환하도록 처리했습니다.  
- Postman 테스트를 통해 정상 동작을 확인했습니다.
- **PR 리뷰 반영하여 수정 완료했습니다.**

---

### Changes  
- `GET /api/stores` 매장 전체 조회 API 구현
- 검색어(가게 이름) 부분 검색 기능 적용
- 페이지네이션 기능 적용 (`page`, `size` 파라미터)
- 매장이 없는 경우 200 OK와 빈 배열 반환
- Postman을 통한 정상 동작 검증 완료
- **@PageableDefault(page=0, size=10) 적용 및 구조 간결화**
- **page/size 입력값 보정**
- **매직 넘버 제거 및 상수화**

---

### Screenshots  

#### ✅ 200 OK
![200](https://github.com/user-attachments/assets/f9178439-ba66-4d21-94ed-3b248a6927f6)

#### ❌ 401 UNAUTHORIZED
![401](https://github.com/user-attachments/assets/98dc4490-b6ab-46f0-8c69-6ac8530637f9)