### PR TITLE
[Menu] 메뉴 전체 조회 API 개발 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/controller/MenuController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/controller/MenuController.java
@@ -2,13 +2,16 @@ package com.delivery.igo.igo_delivery.api.menu.controller;
 
 import com.delivery.igo.igo_delivery.api.menu.dto.request.MenuRequestDto;
 import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuResponseDto;
+import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuReadResponseDto;
 import com.delivery.igo.igo_delivery.api.menu.service.MenuService;
 import com.delivery.igo.igo_delivery.common.annotation.Auth;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -40,5 +43,13 @@ public class MenuController {
         MenuResponseDto responseDto = menuService.updateMenu(authUser, storesId, id, requestDto);
 
         return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MenuReadResponseDto>> findAllMenu(@PathVariable Long storesId) {
+
+        List<MenuReadResponseDto> allMenu = menuService.findAllMenu(storesId);
+
+        return ResponseEntity.ok(allMenu);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/dto/response/MenuReadResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/dto/response/MenuReadResponseDto.java
@@ -1,0 +1,26 @@
+package com.delivery.igo.igo_delivery.api.menu.dto.response;
+
+import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MenuReadResponseDto {
+
+    private final Long id;
+
+    private final String menuName;
+
+    private final Long price;
+
+    private final LocalDateTime createdAt;
+
+    private final LocalDateTime modifiedAt;
+
+    public static MenuReadResponseDto from(Menus menus) {
+
+        return new MenuReadResponseDto(menus.getId(), menus.getMenuName(), menus.getPrice(), menus.getCreatedAt(), menus.getModifiedAt());
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/entity/Menus.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/entity/Menus.java
@@ -48,20 +48,20 @@ public class Menus extends BaseEntity {
         this.menuStatus = MenuStatus.INACTIVE;
     }
 
-    public static Menus of(Stores stores, MenuRequestDto requestDto) {
+    public static Menus of(Stores stores, String menuName, Long price) {
 
         return Menus.builder()
                 .stores(stores)
-                .menuName(requestDto.getMenuName())
-                .price(requestDto.getPrice())
+                .menuName(menuName)
+                .price(price)
                 .menuStatus(MenuStatus.LIVE)
                 .build();
     }
 
-    public void updateMenu(MenuRequestDto requestDto) {
+    public void updateMenu(String menuName, Long price) {
 
-        this.menuName = requestDto.getMenuName();
-        this.price = requestDto.getPrice();
+        this.menuName = menuName;
+        this.price = price;
     }
 
     public void validateDelete() {

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/repository/MenuRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/repository/MenuRepository.java
@@ -1,10 +1,18 @@
 package com.delivery.igo.igo_delivery.api.menu.repository;
 
+import com.delivery.igo.igo_delivery.api.menu.entity.MenuStatus;
 import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MenuRepository extends JpaRepository<Menus, Long> {
 
     Optional<Menus> findByIdAndStoresId(Long id, Long storesId);
+
+    @Query("SELECT m FROM Menus m WHERE m.stores.id = :storesId AND m.menuStatus = :menuStatus ORDER BY m.createdAt DESC")
+    List<Menus> findMenusByStoreIdOrderByCreatedAtDesc(@Param("storesId") Long storesId,
+                                                       @Param("menuStatus") MenuStatus menuStatus);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuService.java
@@ -2,11 +2,15 @@ package com.delivery.igo.igo_delivery.api.menu.service;
 
 import com.delivery.igo.igo_delivery.api.menu.dto.request.MenuRequestDto;
 import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuResponseDto;
+import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuReadResponseDto;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import java.util.List;
 
 public interface MenuService {
 
     MenuResponseDto createMenu(AuthUser authUser, Long storesId, MenuRequestDto requestDto);
 
     MenuResponseDto updateMenu(AuthUser authUser, Long storesId, Long id, MenuRequestDto requestDto);
+
+    List<MenuReadResponseDto> findAllMenu(Long storesId);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImpl.java
@@ -38,7 +38,7 @@ public class MenuServiceImpl implements MenuService {
                 .orElseThrow(() -> new GlobalException(ErrorCode.STORE_NOT_FOUND));
         store.validateOwner(user);
 
-        Menus menu = Menus.of(store, requestDto);
+        Menus menu = Menus.of(store, requestDto.getMenuName(), requestDto.getPrice());
         Menus savedMenu = menuRepository.save(menu);
 
         return MenuResponseDto.from(savedMenu);
@@ -60,7 +60,7 @@ public class MenuServiceImpl implements MenuService {
         Menus menu = menuRepository.findByIdAndStoresId(id, storesId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.MENU_NOT_FOUND));
         menu.validateDelete();
-        menu.updateMenu(requestDto);
+        menu.updateMenu(requestDto.getMenuName(), requestDto.getPrice());
 
         return MenuResponseDto.from(menu);
     }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImpl.java
@@ -1,7 +1,9 @@
 package com.delivery.igo.igo_delivery.api.menu.service;
 
 import com.delivery.igo.igo_delivery.api.menu.dto.request.MenuRequestDto;
+import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuReadResponseDto;
 import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuResponseDto;
+import com.delivery.igo.igo_delivery.api.menu.entity.MenuStatus;
 import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
 import com.delivery.igo.igo_delivery.api.menu.repository.MenuRepository;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;
@@ -11,6 +13,8 @@ import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,6 +55,17 @@ public class MenuServiceImpl implements MenuService {
         menu.updateMenu(requestDto.getMenuName(), requestDto.getPrice());
 
         return MenuResponseDto.from(menu);
+    }
+
+    @Override
+    public List<MenuReadResponseDto> findAllMenu(Long storesId) {
+
+        Stores store = storeRepository.findById(storesId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.STORE_NOT_FOUND));
+
+        List<Menus> menusList = menuRepository.findMenusByStoreIdOrderByCreatedAtDesc(storesId, MenuStatus.LIVE);
+
+        return menusList.stream().map(MenuReadResponseDto::from).collect(Collectors.toList());
     }
 
     private Users getUserWithAccessCheck(Long id) {

--- a/src/main/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/review/service/ReviewServiceImpl.java
@@ -7,7 +7,6 @@ import com.delivery.igo.igo_delivery.api.order.repository.OrderItemsRepository;
 import com.delivery.igo.igo_delivery.api.order.repository.OrderRepository;
 import com.delivery.igo.igo_delivery.api.review.dto.ReviewRequestDto;
 import com.delivery.igo.igo_delivery.api.review.dto.ReviewResponseDto;
-import com.delivery.igo.igo_delivery.api.review.dto.ReviewUpdateRequestDto;
 import com.delivery.igo.igo_delivery.api.review.entity.Reviews;
 import com.delivery.igo.igo_delivery.api.review.repository.ReviewRepository;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;

--- a/src/test/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceCreateTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceCreateTest.java
@@ -71,7 +71,7 @@ class MenuServiceCreateTest {
     void menus_메뉴_생성에_성공한다() {
 
         MenuRequestDto requestDto = new MenuRequestDto("메뉴 이름", 1000L);
-        Menus menu = Menus.of(store, requestDto);
+        Menus menu = Menus.of(store, requestDto.getMenuName(), requestDto.getPrice());
         Long storeId = 1L;
 
         given(userRepository.findById(authUser.getId())).willReturn(Optional.of(user));
@@ -103,7 +103,7 @@ class MenuServiceCreateTest {
                 .build();
 
         MenuRequestDto requestDto = new MenuRequestDto("메뉴 이름", 1000L);
-        Menus menu = Menus.of(store, requestDto);
+        Menus menu = Menus.of(store, requestDto.getMenuName(), requestDto.getPrice());
         Long storeId = 1L;
 
         given(userRepository.findById(otherAuthUser.getId())).willReturn(Optional.of(otherUser));
@@ -133,7 +133,7 @@ class MenuServiceCreateTest {
                 .build();
 
         MenuRequestDto requestDto = new MenuRequestDto("메뉴 이름", 1000L);
-        Menus menu = Menus.of(store, requestDto);
+        Menus menu = Menus.of(store, requestDto.getMenuName(), requestDto.getPrice());
         Long storeId = 1L;
 
         given(userRepository.findById(otherAuthUser.getId())).willThrow(new GlobalException(ErrorCode.ROLE_OWNER_FORBIDDEN));

--- a/src/test/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceReadTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceReadTest.java
@@ -1,0 +1,115 @@
+package com.delivery.igo.igo_delivery.api.menu.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuReadResponseDto;
+import com.delivery.igo.igo_delivery.api.menu.entity.MenuStatus;
+import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import com.delivery.igo.igo_delivery.api.menu.repository.MenuRepository;
+import com.delivery.igo.igo_delivery.api.store.entity.Stores;
+import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MenuServiceReadTest {
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @InjectMocks
+    private MenuServiceImpl menuService;
+
+    private Stores store;
+
+    private Menus menu1;
+
+    private Menus menu2;
+
+    private Menus menu3;
+
+    @BeforeEach
+    void setUp() {
+
+        store = Stores.builder()
+                .id(1L)
+                .storeName("Test Store")
+                .build();
+
+        menu1 = Menus.builder()
+                .id(1L)
+                .stores(store)
+                .menuName("Test Menu 1")
+                .price(1000L)
+                .menuStatus(MenuStatus.LIVE)
+                .build();
+
+        menu2 = Menus.builder()
+                .id(2L)
+                .stores(store)
+                .menuName("Test Menu 2")
+                .price(2000L)
+                .menuStatus(MenuStatus.LIVE)
+                .build();
+
+        menu3 = Menus.builder()
+                .id(2L)
+                .stores(store)
+                .menuName("Test Menu 3")
+                .price(2000L)
+                .menuStatus(MenuStatus.INACTIVE)
+                .build();
+    }
+
+    @Test
+    void menus_메뉴_전체_조회에_성공한다() {
+
+        Long storeId = 1L;
+
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(menuRepository.findMenusByStoreIdOrderByCreatedAtDesc(storeId, MenuStatus.LIVE)).willReturn(
+                List.of(menu1, menu2));
+
+        List<MenuReadResponseDto> result = menuService.findAllMenu(storeId);
+
+        assertThat(result).hasSize(2);
+        assertEquals(result.get(0).getMenuName(), "Test Menu 1");
+        assertEquals(result.get(1).getMenuName(), "Test Menu 2");
+
+        verify(storeRepository).findById(storeId);
+        verify(menuRepository).findMenusByStoreIdOrderByCreatedAtDesc(storeId, MenuStatus.LIVE);
+    }
+
+    @Test
+    void menus_매장이_존재하지_않는_경우_메뉴_전체_조회에_실패한다() {
+
+        Long storeId = 2L;
+
+        given(storeRepository.findById(storeId)).willThrow(new GlobalException(ErrorCode.STORE_NOT_FOUND));
+
+        GlobalException exception = assertThrows(GlobalException.class, () -> {
+            menuService.findAllMenu(storeId);
+        });
+
+        assertEquals(ErrorCode.STORE_NOT_FOUND, exception.getErrorCode());
+
+        verify(storeRepository).findById(storeId);
+        verify(menuRepository, never()).findMenusByStoreIdOrderByCreatedAtDesc(storeId, MenuStatus.LIVE);
+    }
+}


### PR DESCRIPTION
## Description
1. 메뉴 전체 조회 API
  - URL을 /api/stores/{storesId}/menus로 지정해 매장 없이 메뉴가 조회될 수 없도록 설정
  - 조회하려는 매장이 존재하지 않을 시 예외처리
  - 조회된 메뉴는 List 형태로 출력
  - 아직 메뉴가 존재하지 않을 시 빈 배열로 출력
  - 조회된 메뉴는 생성일 순으로 내림차순 정렬
  - 삭제된 메뉴는 조회되지 않음

## Changes
- `Menus` 엔티티에서 `Dto`를 의존하지 않도록 수정
- `MenuServiceImpl`에 `getUserWithAccessCheck()`, `getStoreWithAccessCheck()`, `getMenuWithAccessCheck()` 추가
- `MenuController`, `MenuServiceImpl`에 `findAllMenu()` 추가
- `MenuReadResponseDto` 추가
- `MenuRepository`에 `findMenusByStoreIdOrderByCreatedAtDesc()` 추가

## Screenshots
- 테스트 결과
<img width="520" alt="스크린샷 2025-04-27 오후 12 48 07" src="https://github.com/user-attachments/assets/6c3f686a-a93f-46f4-a37b-1789fc921167" />

- 아직 메뉴가 존재하지 않은 경우 Postman
<img width="892" alt="스크린샷 2025-04-27 오전 11 32 37" src="https://github.com/user-attachments/assets/2e744081-5118-4e71-b9bd-8b823b126fbb" />

- 메뉴 조회 성공 Postman
<img width="891" alt="스크린샷 2025-04-27 오전 11 33 33" src="https://github.com/user-attachments/assets/d36c2626-52e5-4067-9921-0d36b584c991" />

- 존재하지 않는 매장을 조회하려는 경우 Postman
<img width="931" alt="스크린샷 2025-04-27 오후 12 45 51" src="https://github.com/user-attachments/assets/c32c9ee7-304d-4d48-8754-efed065334a9" />
