### PR TITLE
[Order] 주문 목록 조회 추가, 주문 관련 로직 추가, 테스트 코드 리팩토링

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/order/controller/OrderController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/order/controller/OrderController.java
@@ -2,16 +2,18 @@ package com.delivery.igo.igo_delivery.api.order.controller;
 
 import com.delivery.igo.igo_delivery.api.order.dto.*;
 import com.delivery.igo.igo_delivery.api.order.service.OrderService;
-import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
 import com.delivery.igo.igo_delivery.common.annotation.Auth;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
-import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
-import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import com.delivery.igo.igo_delivery.common.dto.PageResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequestMapping("/api/orders")
@@ -47,5 +49,24 @@ public class OrderController {
             @PathVariable Long ordersId
     ){
         return ResponseEntity.ok(orderService.findOrder(authUser,ordersId));
+    }
+
+    //주문 목록 조회
+    @GetMapping
+    public ResponseEntity<PageResponseDto<OrderListResponse>> findOrderList(
+            @Auth AuthUser authUser,
+            //page, size 입력값 검증
+            @PageableDefault(page = 0, size = 5)Pageable pageable
+    ){
+        Page<OrderListResponse> orderListResponse = orderService.findOrderList(authUser.getId(),pageable);
+        PageResponseDto<OrderListResponse> orderPageResponse = new PageResponseDto<>(
+                                    orderListResponse.getContent(),
+                                    orderListResponse.getTotalElements(),
+                                    orderListResponse.getNumber(),
+                                    orderListResponse.getSize(),
+                                    orderListResponse.getTotalPages()
+
+        );
+        return ResponseEntity.ok(orderPageResponse);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/order/dto/OrderListResponse.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/order/dto/OrderListResponse.java
@@ -1,0 +1,31 @@
+package com.delivery.igo.igo_delivery.api.order.dto;
+
+import com.delivery.igo.igo_delivery.api.order.entity.OrderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class OrderListResponse {
+
+    private final String storeName;
+    private final String menuName;
+    private final Long orderPrice;
+    private final Integer countMenuType;
+    private final LocalDateTime createdAt;
+    private final OrderStatus orderStatus;
+
+
+    public static OrderListResponse from(String storeName,
+                                         String menuName,
+                                         Long orderPrice,
+                                         int countMenuType,
+                                         LocalDateTime createdAt,
+                                         OrderStatus orderStatus
+                                         ){
+        return new OrderListResponse(
+                storeName, menuName, orderPrice, countMenuType, createdAt, orderStatus);
+    }
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/order/entity/OrderItems.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/order/entity/OrderItems.java
@@ -38,6 +38,11 @@ public class OrderItems {
     public OrderItems(Orders orders, CartItems cartItems){
         this.orders= orders;
         this.menus = cartItems.getMenus();
+        this.orderItemPrice = cartItems.getCartPrice();
         this.orderQuantity = cartItems.getCartQuantity();
+    }
+
+    public long totalPrice() {
+        return orderItemPrice * orderQuantity.longValue();
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/order/repository/OrderRepository.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/order/repository/OrderRepository.java
@@ -1,7 +1,20 @@
 package com.delivery.igo.igo_delivery.api.order.repository;
 
 import com.delivery.igo.igo_delivery.api.order.entity.Orders;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface OrderRepository extends JpaRepository<Orders, Long> {
+
+    Page<Orders> findByUsersId(Long id, Pageable pageable);
+
+    // 1. userId로 해당 유저가 소유한 store를 호출
+    // 2. 해당 store의 해당 menu가 들어있는 orderItems만 호출
+    // 3. 해당 orderItems에 있는 모든 orderId로 orders를 호출
+    @Query("SELECT o FROM Orders o JOIN OrderItems oi ON o = oi.orders JOIN oi.menus m JOIN m.stores s WHERE s.users.id = :userId")
+    Page<Orders> findByOwnerId(Long userId, Pageable pageable);
+
+
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/order/service/OrderService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/order/service/OrderService.java
@@ -1,10 +1,9 @@
 package com.delivery.igo.igo_delivery.api.order.service;
 
-import com.delivery.igo.igo_delivery.api.order.dto.ChangeOrderStatusRequest;
-import com.delivery.igo.igo_delivery.api.order.dto.ChangeOrderStatusResponse;
-import com.delivery.igo.igo_delivery.api.order.dto.CreateOrderRequest;
-import com.delivery.igo.igo_delivery.api.order.dto.OrderResponse;
+import com.delivery.igo.igo_delivery.api.order.dto.*;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 
 public interface OrderService {
@@ -14,4 +13,6 @@ public interface OrderService {
     ChangeOrderStatusResponse changeOrderStatus(AuthUser authUser, ChangeOrderStatusRequest request, Long ordersId);
 
     OrderResponse findOrder(AuthUser authUser, Long ordersId);
+
+    Page<OrderListResponse> findOrderList(Long authId, Pageable pageable);
 }

--- a/src/test/java/com/delivery/igo/igo_delivery/api/order/service/OrderServiceImplTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/order/service/OrderServiceImplTest.java
@@ -24,10 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 
 import java.sql.Time;
 import java.time.LocalTime;
@@ -145,7 +142,7 @@ class OrderServiceTest {
                 .orders(orders)
                 .build();
         orderItemsList = List.of(orderItems);
-        pageable = PageRequest.of(0, 5);
+        pageable = PageRequest.of(0, 5, Sort.by(Sort.Order.desc("createdAt")));
     }
 
     @Test


### PR DESCRIPTION

## Description
- 주문 목록 조회 추가
- 로그인한 유저의 userRole이 CONSUMER일 경우 본인의 주문 목록 출력
- 로그인한 유저의 userRole이 OWNER일 경우 본인의 매장 주문 목록 출력
- 관련 테스트 코드 성공 케이스만 추가 (예외 관련 후에 추가 예정)
## Changes
- 주문 생성시 주문 시 장바구니 목록 초기화 로직 추가
## Screenshots
![image](https://github.com/user-attachments/assets/fd798aa3-c180-4bda-a7bb-2ee2275d0da2)

테스트 실행 이미지
## Ref
- 페이징은 수현님의 코드를 참고 하여 작성하였습니다. 감사합니다.