### PR TITLE
[Store] 매장 단건 조회 기능 추가

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
@@ -48,7 +48,7 @@ public class StoreController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/api/stores/{id}")
+    @GetMapping("/{id}")
     public ResponseEntity<StoreResponseDto> getStore(@PathVariable Long id) {
         StoreResponseDto response = storeService.getStore(id);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
@@ -47,4 +47,10 @@ public class StoreController {
 
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/api/stores/{id}")
+    public ResponseEntity<StoreResponseDto> getStore(@PathVariable Long id) {
+        StoreResponseDto response = storeService.getStore(id);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreResponseDto.java
@@ -1,5 +1,6 @@
 package com.delivery.igo.igo_delivery.api.store.dto;
 
+import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuReadResponseDto;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,23 +8,25 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 
 @Getter
 @Builder
 @AllArgsConstructor
 public class StoreResponseDto {
-    private Long id;                    // 매장 ID
-    private String storeName;           // 매장 이름
-    private String storeAddress;        // 매장 주소
-    private String storePhoneNumber;    // 매장 전화번호
-    private LocalTime openTime;         // 영업 시작 시간
-    private LocalTime endTime;          // 영업 종료 시간
-    private Integer minOrderPrice;      // 최소 주문 금액
-    private String storeStatus;         // 매장 상태 (LIVE, CLOSED 등)
-    private LocalDateTime createdAt;    // 생성 시각
-    private LocalDateTime modifiedAt;   // 수정 시각
+    private Long id;                            // 매장 ID
+    private String storeName;                   // 매장 이름
+    private String storeAddress;                // 매장 주소
+    private String storePhoneNumber;            // 매장 전화번호
+    private LocalTime openTime;                 // 영업 시작 시간
+    private LocalTime endTime;                  // 영업 종료 시간
+    private Integer minOrderPrice;              // 최소 주문 금액
+    private String storeStatus;                 // 매장 상태 (LIVE, CLOSED 등)
+    private List<MenuReadResponseDto> menus;    // 등록된 메뉴 목록
+    private LocalDateTime createdAt;            // 생성 시각
+    private LocalDateTime modifiedAt;           // 수정 시각
 
-    // 매장 엔티티를 응답용 DTO로 변환
+    // 매장 entity를 응답용 DTO로 변환(메뉴 없음)
     public static StoreResponseDto from(Stores store) {
         return StoreResponseDto.builder()
                 .id(store.getId())
@@ -34,6 +37,23 @@ public class StoreResponseDto {
                 .endTime(store.getEndTime().toLocalTime())
                 .minOrderPrice(store.getMinOrderPrice())
                 .storeStatus(store.getStoreStatus().name())
+                .createdAt(store.getCreatedAt())
+                .modifiedAt(store.getModifiedAt())
+                .build();
+    }
+
+    // 매장 entity를 응답용 DTO로 변환(메뉴 있음)
+    public static StoreResponseDto from(Stores store, List<MenuReadResponseDto> menus) {
+        return StoreResponseDto.builder()
+                .id(store.getId())
+                .storeName(store.getStoreName())
+                .storeAddress(store.getStoreAddress())
+                .storePhoneNumber(store.getStorePhoneNumber())
+                .openTime(store.getOpenTime().toLocalTime())
+                .endTime(store.getEndTime().toLocalTime())
+                .minOrderPrice(store.getMinOrderPrice())
+                .storeStatus(store.getStoreStatus().name())
+                .menus(menus)
                 .createdAt(store.getCreatedAt())
                 .modifiedAt(store.getModifiedAt())
                 .build();

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreService.java
@@ -3,16 +3,17 @@ package com.delivery.igo.igo_delivery.api.store.service;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreListResponseDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
-import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface StoreService {
 
     // 매장 생성
-    @Transactional
     StoreResponseDto createStore(StoreRequestDto requestDto, Long userId);
 
     // 매장 전체 조회
     Page<StoreListResponseDto> getStores(String storeName, Pageable pageable);
+
+    // 매장 단건 조회
+    StoreResponseDto getStore(Long storeId);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -10,12 +10,12 @@ import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
 import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
 import com.delivery.igo.igo_delivery.common.exception.GlobalException;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,8 +30,8 @@ public class StoreServiceImpl implements StoreService {
     private static final int MAX_PAGE_SIZE = 50;
 
     // 매장 생성
-    @Transactional
     @Override
+    @Transactional
     public StoreResponseDto createStore(StoreRequestDto requestDto, Long userId) {
         Users owner = userRepository.findById(userId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
@@ -54,6 +54,7 @@ public class StoreServiceImpl implements StoreService {
 
     // 매장 전체 조회
     @Override
+    @Transactional(readOnly = true)
     public Page<StoreListResponseDto> getStores(String storeName, Pageable pageable) {
         int page = pageable.getPageNumber();
         int size = pageable.getPageSize();
@@ -81,5 +82,14 @@ public class StoreServiceImpl implements StoreService {
 
         // 조회된 매장들을 StoreListResponseDto로 변환하여 반환
         return stores.map(StoreListResponseDto::from);
+    }
+
+    // 매장 단건 조회
+    @Override
+    @Transactional(readOnly = true)
+    public StoreResponseDto getStore(Long storeId) {
+        Stores store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.STORE_NOT_FOUND));
+        return StoreResponseDto.from(store);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -1,5 +1,7 @@
 package com.delivery.igo.igo_delivery.api.store.service;
 
+import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuReadResponseDto;
+import com.delivery.igo.igo_delivery.api.menu.service.MenuService;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreListResponseDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
@@ -17,12 +19,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class StoreServiceImpl implements StoreService {
 
     private final StoreRepository storeRepository;
     private final UserRepository userRepository;
+    private final MenuService menuService;
 
     private static final int DEFAULT_PAGE_NUMBER = 0;
     private static final int MIN_PAGE_SIZE = 1;
@@ -90,6 +95,10 @@ public class StoreServiceImpl implements StoreService {
     public StoreResponseDto getStore(Long storeId) {
         Stores store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.STORE_NOT_FOUND));
-        return StoreResponseDto.from(store);
+
+        // 해당 매장의 등록된 메뉴 목록 조회
+        List<MenuReadResponseDto> menus = menuService.findAllMenu(storeId);
+
+        return StoreResponseDto.from(store, menus);
     }
 }

--- a/src/test/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceTest.java
@@ -2,12 +2,15 @@ package com.delivery.igo.igo_delivery.api.store.service;
 
 import com.delivery.igo.igo_delivery.api.store.dto.StoreListResponseDto;
 import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
+import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
 import com.delivery.igo.igo_delivery.api.store.entity.StoreStatus;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;
 import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
 import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
 import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,12 +22,15 @@ import org.springframework.data.domain.PageRequest;
 
 
 import java.sql.Time;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -165,5 +171,43 @@ public class StoreServiceTest {
         // then
         assertThat(result.getTotalElements()).isZero();
         assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    void 매장_단건_조회_성공() {
+
+        // given
+        Stores store = Stores.builder()
+                .id(1L)
+                .storeName("초코라떼가제일좋아")
+                .storeAddress("인천시 미추홀구")
+                .storePhoneNumber("010-8282-8282")
+                .openTime(Time.valueOf(LocalTime.of(8, 0)))
+                .endTime(Time.valueOf(LocalTime.of(22, 0)))
+                .minOrderPrice(10000)
+                .storeStatus(StoreStatus.LIVE)
+                .build();
+
+        given(storeRepository.findById(1L)).willReturn(Optional.of(store));
+
+        // when
+        StoreResponseDto response = storeService.getStore(1L);
+
+        // then
+        assertThat(response.getStoreName()).isEqualTo("초코라떼가제일좋아");
+        assertThat(response.getStoreAddress()).isEqualTo("인천시 미추홀구");
+        assertThat(response.getMinOrderPrice()).isEqualTo(10000);
+    }
+
+    @Test
+    void 매장_단건_조회_매장_없음() {
+
+        // given
+        given(storeRepository.findById(9999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> storeService.getStore(9999L))
+                .isInstanceOf(GlobalException.class)
+                .hasMessage(ErrorCode.STORE_NOT_FOUND.getMessage());
     }
 }

--- a/src/test/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceTest.java
@@ -22,7 +22,6 @@ import org.springframework.data.domain.PageRequest;
 
 
 import java.sql.Time;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
### Description  
- 매장 단건 조회 기능을 구현했습니다.
- 존재하지 않는 매장 ID 요청 시 404 Not Found를 반환합니다.
- Postman 테스트를 통해 정상 동작을 확인했습니다.
- **매장 단건 조회 시 등록된 메뉴 목록을 함께 반환하도록 수정했습니다.**

---

### Changes  
- `GET /api/stores/{id}` 매장 단건 조회 API 구현
- 존재하지 않는 매장 ID 요청 시 GlobalException 처리 적용
- 매장 단건 조회 서비스 성공/실패 테스트 코드 작성
- Postman을 통한 정상 동작 검증 완료

---

### Screenshots  

#### ✅ 200 OK
![200](https://github.com/user-attachments/assets/9558445e-00e7-49a4-bac5-a315a81fc73c)

#### ❌ 401 UNAUTHORIZED
![401](https://github.com/user-attachments/assets/e083bdcd-fff0-4e00-9426-dfb6f8f158b0)

#### ❌ 404 NOT FOUND
![401](https://github.com/user-attachments/assets/78466054-8718-40ff-bbca-5a4099b64d84)