### PR TITLE
[Menu] 메뉴 단건 조회 API 개발 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/controller/MenuController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/controller/MenuController.java
@@ -52,4 +52,12 @@ public class MenuController {
 
         return ResponseEntity.ok(allMenu);
     }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<MenuReadResponseDto> findMenuById(@PathVariable Long storesId, @PathVariable Long id) {
+
+        MenuReadResponseDto responseDto = menuService.findMenuById(storesId, id);
+
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuService.java
@@ -13,4 +13,6 @@ public interface MenuService {
     MenuResponseDto updateMenu(AuthUser authUser, Long storesId, Long id, MenuRequestDto requestDto);
 
     List<MenuReadResponseDto> findAllMenu(Long storesId);
+
+    MenuReadResponseDto findMenuById(Long storesId, Long id);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImpl.java
@@ -68,6 +68,17 @@ public class MenuServiceImpl implements MenuService {
         return menusList.stream().map(MenuReadResponseDto::from).collect(Collectors.toList());
     }
 
+    @Override
+    public MenuReadResponseDto findMenuById(Long storesId, Long id) {
+
+        Stores store = storeRepository.findById(storesId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.STORE_NOT_FOUND));
+
+        Menus findMenu = getMenuWithAccessCheck(id, storesId);
+
+        return MenuReadResponseDto.from(findMenu);
+    }
+
     private Users getUserWithAccessCheck(Long id) {
 
         Users user = userRepository.findById(id)

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImpl.java
@@ -58,6 +58,7 @@ public class MenuServiceImpl implements MenuService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<MenuReadResponseDto> findAllMenu(Long storesId) {
 
         Stores store = storeRepository.findById(storesId)
@@ -69,6 +70,7 @@ public class MenuServiceImpl implements MenuService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public MenuReadResponseDto findMenuById(Long storesId, Long id) {
 
         Stores store = storeRepository.findById(storesId)


### PR DESCRIPTION
## Description
- 메뉴 단건 조회 API
  - 조회하려는 매장이 존재하지 않을 시 예외처리
  - 조회하려는 메뉴가 존재하지 않을 시 예외처리
  - 삭제된 메뉴는 조회되지 않음
## Changes
- `MenuController`, `MenuService`에 `findMenuById` 추가
- 조회 메서드에 `@Transactional(readOnly = true)` 추가
## Screenshots
- 테스트 결과
<img width="515" alt="스크린샷 2025-04-27 오후 3 23 34" src="https://github.com/user-attachments/assets/b7a5b8fd-e8e4-4459-b181-8ce7397896b9" />

- 존재하지 않은 메뉴를 조회할 경우 Postman
<img width="929" alt="스크린샷 2025-04-27 오후 4 17 57" src="https://github.com/user-attachments/assets/17ef4000-1508-4540-95a2-e7416a1dfe11" />

- 존재하지 않은 매장을 조회하는 경우 Postman
<img width="927" alt="스크린샷 2025-04-27 오후 4 25 12" src="https://github.com/user-attachments/assets/01b6a81c-7e85-4e47-bf33-2f76f3dd4789" />

- 메뉴 조회 성공 Postman
<img width="932" alt="스크린샷 2025-04-27 오후 4 18 27" src="https://github.com/user-attachments/assets/46ab46bd-9e6d-4aac-baf1-e0e1dfaf8e05" />
