### PR TITLE
[Store] 매장 수정 기능 구현

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
@@ -58,7 +58,7 @@ public class StoreController {
     public ResponseEntity<StoreUpdateResponseDto> updateStore(
             @PathVariable Long id,
             @Auth AuthUser authUser,
-            @RequestBody StoreUpdateRequestDto requestDto
+            @Valid @RequestBody StoreUpdateRequestDto requestDto
     ) {
         StoreUpdateResponseDto response = storeService.updateStore(id, authUser.getId(), requestDto);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/controller/StoreController.java
@@ -1,8 +1,6 @@
 package com.delivery.igo.igo_delivery.api.store.controller;
 
-import com.delivery.igo.igo_delivery.api.store.dto.StoreListResponseDto;
-import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
-import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
+import com.delivery.igo.igo_delivery.api.store.dto.*;
 import com.delivery.igo.igo_delivery.api.store.service.StoreService;
 import com.delivery.igo.igo_delivery.common.annotation.Auth;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
@@ -48,9 +46,21 @@ public class StoreController {
         return ResponseEntity.ok(response);
     }
 
+    // 매장 단건 조회
     @GetMapping("/{id}")
     public ResponseEntity<StoreResponseDto> getStore(@PathVariable Long id) {
         StoreResponseDto response = storeService.getStore(id);
+        return ResponseEntity.ok(response);
+    }
+
+    // 매장 수정
+    @PutMapping("/{id}")
+    public ResponseEntity<StoreUpdateResponseDto> updateStore(
+            @PathVariable Long id,
+            @Auth AuthUser authUser,
+            @RequestBody StoreUpdateRequestDto requestDto
+    ) {
+        StoreUpdateResponseDto response = storeService.updateStore(id, authUser.getId(), requestDto);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreUpdateRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package com.delivery.igo.igo_delivery.api.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreUpdateRequestDto {
+    private String storeName;           // 매장 이름
+    private String storeAddress;        // 매장 주소
+    private String storePhoneNumber;    // 매장 전화번호
+    private LocalTime openTime;         // 영업 시작 시간
+    private LocalTime endTime;          // 영업 종료 시간
+    private Integer minOrderPrice;      // 최소 주문 금액
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreUpdateRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreUpdateRequestDto.java
@@ -1,5 +1,7 @@
 package com.delivery.igo.igo_delivery.api.store.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +12,22 @@ import java.time.LocalTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StoreUpdateRequestDto {
+
+    @NotBlank
     private String storeName;           // 매장 이름
+
+    @NotBlank
     private String storeAddress;        // 매장 주소
+
+    @NotBlank
     private String storePhoneNumber;    // 매장 전화번호
+
+    @NotNull
     private LocalTime openTime;         // 영업 시작 시간
+
+    @NotNull
     private LocalTime endTime;          // 영업 종료 시간
+
+    @NotNull
     private Integer minOrderPrice;      // 최소 주문 금액
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreUpdateResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/dto/StoreUpdateResponseDto.java
@@ -1,0 +1,12 @@
+package com.delivery.igo.igo_delivery.api.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class StoreUpdateResponseDto {
+    private Long id;    // 매장 ID
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/entity/Stores.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/entity/Stores.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 
 import java.sql.Time;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Objects;
 
 @Entity
@@ -70,5 +71,16 @@ public class Stores extends BaseEntity {
         if (!Objects.equals(this.getUsers().getId(), user.getId())) {
             throw new GlobalException(ErrorCode.STORE_OWNER_MISMATCH);
         }
+    }
+
+    // 매장 정보 수정
+    public void updateStoreInfo(String storeName, String storeAddress, String storePhoneNumber,
+                                LocalTime openTime, LocalTime endTime, Integer minOrderPrice) {
+        this.storeName = storeName;                 // 매장 이름 수정
+        this.storeAddress = storeAddress;           // 매장 주소 수정
+        this.storePhoneNumber = storePhoneNumber;   // 매장 전화번호 수정
+        this.openTime = Time.valueOf(openTime);     // 영업 시작 시간 수정
+        this.endTime = Time.valueOf(endTime);       // 영업 종료 시간 수정
+        this.minOrderPrice = minOrderPrice;         // 최소 주문 금액 수정
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreService.java
@@ -1,8 +1,6 @@
 package com.delivery.igo.igo_delivery.api.store.service;
 
-import com.delivery.igo.igo_delivery.api.store.dto.StoreListResponseDto;
-import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
-import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
+import com.delivery.igo.igo_delivery.api.store.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -16,4 +14,7 @@ public interface StoreService {
 
     // 매장 단건 조회
     StoreResponseDto getStore(Long storeId);
+
+    // 매장 수정
+    StoreUpdateResponseDto updateStore(Long storeId, Long authUserId, StoreUpdateRequestDto requestDto);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/store/service/StoreServiceImpl.java
@@ -2,9 +2,7 @@ package com.delivery.igo.igo_delivery.api.store.service;
 
 import com.delivery.igo.igo_delivery.api.menu.dto.response.MenuReadResponseDto;
 import com.delivery.igo.igo_delivery.api.menu.service.MenuService;
-import com.delivery.igo.igo_delivery.api.store.dto.StoreListResponseDto;
-import com.delivery.igo.igo_delivery.api.store.dto.StoreRequestDto;
-import com.delivery.igo.igo_delivery.api.store.dto.StoreResponseDto;
+import com.delivery.igo.igo_delivery.api.store.dto.*;
 import com.delivery.igo.igo_delivery.api.store.entity.StoreStatus;
 import com.delivery.igo.igo_delivery.api.store.entity.Stores;
 import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
@@ -100,5 +98,31 @@ public class StoreServiceImpl implements StoreService {
         List<MenuReadResponseDto> menus = menuService.findAllMenu(storeId);
 
         return StoreResponseDto.from(store, menus);
+    }
+
+    // 매장 수정
+    @Transactional
+    public StoreUpdateResponseDto updateStore(Long storeId, Long authUserId, StoreUpdateRequestDto requestDto) {
+        Stores store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.STORE_NOT_FOUND));
+
+        // 매장의 소유자가 현재 사용자와 일치하는지 검증
+        if (!store.getUsers().getId().equals(authUserId)) {
+            throw new GlobalException(ErrorCode.STORE_OWNER_MISMATCH);
+        }
+
+        // 매장 정보를 요청 값으로 수정
+        store.updateStoreInfo(
+                requestDto.getStoreName(),
+                requestDto.getStoreAddress(),
+                requestDto.getStorePhoneNumber(),
+                requestDto.getOpenTime(),
+                requestDto.getEndTime(),
+                requestDto.getMinOrderPrice()
+        );
+
+        return StoreUpdateResponseDto.builder()
+                .id(store.getId())
+                .build();
     }
 }


### PR DESCRIPTION
### Description
- 매장 수정 기능을 구현했습니다.
- 본인 소유 매장만 수정할 수 있도록 권한 검증을 추가했습니다.
- 수정 가능한 항목: 매장 이름, 매장 주소, 전화번호, 오픈 시간, 종료 시간, 최소 주문 금액
- StoreUpdateRequestDto에 @NotBlank, @NotNull 유효성 검증 어노테이션을 추가했습니다.
- Controller에서 @Valid를 적용하여 요청 데이터 검증을 수행하도록 했습니다.
- 매장 수정 성공 및 실패(소유자 불일치, 매장 미존재) 케이스에 대한 테스트 코드를 작성했습니다.
- Postman을 통해 정상 동작을 확인했습니다.

---

### Changes
- `PUT /api/stores/{id}` 매장 수정 API 구현
- 매장 소유자 검증 로직 추가 (본인 매장만 수정 가능)
- StoreUpdateRequestDto 유효성 검증 어노테이션 적용
- 매장 수정 성공/실패에 대한 서비스 테스트 코드 작성
- Postman 테스트를 통해 정상 동작 확인

---

### Screenshots

#### ✅ 200 OK
![200](https://github.com/user-attachments/assets/c68d796c-e888-484d-8ce6-20cb0b6eac85)

#### ❌ 400 BAD REQUEST
![400](https://github.com/user-attachments/assets/445bf646-ccf5-43da-9cb5-ca5599cef0ef)

#### ❌ 401 UNAUTHORIZED
![401](https://github.com/user-attachments/assets/b124c818-0f2b-4d4c-be4f-2f5913cbdf27)

#### ❌ 403 FORBIDDEN
![403](https://github.com/user-attachments/assets/9b3224fd-2dbd-4f47-8c4d-c4149c6907c5)

#### ❌ 404 NOT FOUND
![404](https://github.com/user-attachments/assets/0014111f-c7fc-4b14-814c-68a3e71d9dd7)