### PR TITLE
[Menu] 메뉴 삭제 API 개발 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/controller/MenuController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/controller/MenuController.java
@@ -11,6 +11,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -59,5 +60,13 @@ public class MenuController {
         MenuReadResponseDto responseDto = menuService.findMenuById(storesId, id);
 
         return ResponseEntity.ok(responseDto);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteMenu(@Auth AuthUser authUser, @PathVariable Long storesId, @PathVariable Long id) {
+
+        menuService.deleteMenu(authUser, storesId, id);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuService.java
@@ -15,4 +15,6 @@ public interface MenuService {
     List<MenuReadResponseDto> findAllMenu(Long storesId);
 
     MenuReadResponseDto findMenuById(Long storesId, Long id);
+
+    void deleteMenu(AuthUser authUser, Long storesId, Long id);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceImpl.java
@@ -81,6 +81,19 @@ public class MenuServiceImpl implements MenuService {
         return MenuReadResponseDto.from(findMenu);
     }
 
+    @Override
+    @Transactional
+    public void deleteMenu(AuthUser authUser, Long storesId, Long id) {
+
+        Users user = getUserWithAccessCheck(authUser.getId());
+
+        Stores store = getStoreWithAccessCheck(storesId, user);
+
+        Menus menu = getMenuWithAccessCheck(id, storesId);
+
+        menu.delete();
+    }
+
     private Users getUserWithAccessCheck(Long id) {
 
         Users user = userRepository.findById(id)

--- a/src/test/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceDeleteTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/menu/service/MenuServiceDeleteTest.java
@@ -1,0 +1,125 @@
+package com.delivery.igo.igo_delivery.api.menu.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.delivery.igo.igo_delivery.api.menu.entity.MenuStatus;
+import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import com.delivery.igo.igo_delivery.api.menu.repository.MenuRepository;
+import com.delivery.igo.igo_delivery.api.store.entity.Stores;
+import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MenuServiceDeleteTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    @InjectMocks
+    private MenuServiceImpl menuService;
+
+    private AuthUser authUser;
+
+    private Users user;
+
+    private Stores store;
+
+    private Menus menu1;
+
+    private Menus menu2;
+
+    @BeforeEach
+    void setUp() {
+        authUser = new AuthUser(1L, "test@gmail.com", "nickname", UserRole.OWNER);
+
+        user = Users.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .nickname("nickname")
+                .userRole(UserRole.OWNER)
+                .build();
+
+        store = Stores.builder()
+                .id(1L)
+                .users(user)
+                .storeName("가게")
+                .build();
+
+        menu1 = Menus.builder()
+                .id(1L)
+                .stores(store)
+                .menuName("Test Menu 1")
+                .price(1000L)
+                .menuStatus(MenuStatus.LIVE)
+                .build();
+
+        menu2 = Menus.builder()
+                .id(2L)
+                .stores(store)
+                .menuName("Test Menu 2")
+                .price(2000L)
+                .menuStatus(MenuStatus.INACTIVE)
+                .build();
+    }
+
+    @Test
+    void menus_메뉴_삭제에_성공한다() {
+
+        Long userId = 1L;
+        Long storeId = 1L;
+        Long menuId = 1L;
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(menuRepository.findByIdAndStoresId(menuId, storeId)).willReturn(Optional.of(menu1));
+
+        menuService.deleteMenu(authUser, storeId, menuId);
+
+        verify(userRepository).findById(userId);
+        verify(storeRepository).findById(storeId);
+        verify(menuRepository).findByIdAndStoresId(menuId, storeId);
+    }
+
+    @Test
+    void menus_이미_삭제된_메뉴를_삭제하려는_경우_메뉴_삭제에_실패한다() {
+
+        Long userId = 1L;
+        Long storeId = 1L;
+        Long menuId = 2L;
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(menuRepository.findByIdAndStoresId(menuId, storeId)).willReturn(Optional.of(menu2));
+
+        GlobalException exception = assertThrows(GlobalException.class, () -> {
+            menuService.deleteMenu(authUser, storeId, menuId);
+        });
+
+        assertEquals(ErrorCode.DELETED_MENU, exception.getErrorCode());
+
+        verify(userRepository).findById(userId);
+        verify(storeRepository).findById(storeId);
+        verify(menuRepository).findByIdAndStoresId(menuId, storeId);
+    }
+}


### PR DESCRIPTION
## Description
- 메뉴 삭제 API
  - 삭제하려는 매장이 존재하지 않은 경우 예외처리
  - 삭제하려는 메뉴가 존재하지 않은 경우 예외처리
  - 이미 삭제된 메뉴를 삭제하려 할 경우 예외처리
  - 해당 매장 주인이 아닌 경우 예외처리
## Changes
- `MenuController`, `MenuService`에 `deleteMenu()` 추가
 
## Screenshots
- 테스트 결과
<img width="526" alt="스크린샷 2025-04-27 오후 8 11 35" src="https://github.com/user-attachments/assets/7d1ee3fd-e046-4901-9558-69dd1110dd76" />

- 메뉴 삭제 성공 Postman
<img width="928" alt="스크린샷 2025-04-27 오후 5 53 06" src="https://github.com/user-attachments/assets/e66310a4-564d-4dd0-b854-ce4acbe7fbec" />

- 이미 삭제된 메뉴를 삭제할 경우 Postman
<img width="927" alt="스크린샷 2025-04-27 오후 5 53 16" src="https://github.com/user-attachments/assets/5b51ba26-7cf0-4bf9-917d-77c45d10efc1" />

- 메뉴 조회시 삭제된 메뉴는 보이지 않음 Postman
<img width="926" alt="스크린샷 2025-04-27 오후 5 53 35" src="https://github.com/user-attachments/assets/30ed5967-2d6d-4171-aea5-8ee063e24857" />

- 이미 삭제된 메뉴를 수정할 경우 Postman
<img width="925" alt="스크린샷 2025-04-27 오후 5 53 59" src="https://github.com/user-attachments/assets/76d0eb2d-259d-4399-8226-2ee3806df6c1" />

- 존재하지 않는 메뉴를 삭제할 경우 Postman
<img width="923" alt="스크린샷 2025-04-27 오후 5 54 20" src="https://github.com/user-attachments/assets/663a5c18-8a68-449a-b3b5-6889d5a2c262" />

- 손님이 메뉴를 삭제할 경우 Postman
<img width="924" alt="스크린샷 2025-04-27 오후 5 56 44" src="https://github.com/user-attachments/assets/65987bdd-4c0c-4ba3-8f08-c5e4a2983dd9" />

- 다른 매장 사장이 메뉴를 삭제할 경우 Postman
<img width="927" alt="스크린샷 2025-04-27 오후 5 57 35" src="https://github.com/user-attachments/assets/61066a35-fcc9-4f07-9846-7792c93dacea" />

- 존재하지 않는 매장에 접근하는 경우
<img width="921" alt="스크린샷 2025-04-27 오후 5 55 01" src="https://github.com/user-attachments/assets/266f7175-8119-4a08-b230-c33dc31753b0" />
