### PR TITLE
[Carts] 장바구니 아이템 수량 증가 및 감소 API 개발 및 성공/실패 통합테스트

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/controller/CartController.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/controller/CartController.java
@@ -2,8 +2,10 @@ package com.delivery.igo.igo_delivery.api.cart.controller;
 
 
 import com.delivery.igo.igo_delivery.api.cart.dto.request.CreateCartRequestDto;
+import com.delivery.igo.igo_delivery.api.cart.dto.request.UpdateCartItemRequestDto;
 import com.delivery.igo.igo_delivery.api.cart.dto.response.CreateCartResponseDto;
 import com.delivery.igo.igo_delivery.api.cart.dto.response.FindAllCartsResponseDto;
+import com.delivery.igo.igo_delivery.api.cart.dto.response.UpdateCartItemResponseDto;
 import com.delivery.igo.igo_delivery.api.cart.service.CartService;
 import com.delivery.igo.igo_delivery.common.annotation.Auth;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
@@ -35,5 +37,14 @@ public class CartController {
         FindAllCartsResponseDto responseDto = cartService.findAllCarts(authUser);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
 
+    }
+
+    @PostMapping("/items/{cartItemId}")
+    public ResponseEntity<UpdateCartItemResponseDto> updateCartItem(@PathVariable Long cartItemId,
+                                                                    @Auth AuthUser authUser,
+                                                                    @Valid @RequestBody UpdateCartItemRequestDto requestDto) {
+
+        UpdateCartItemResponseDto responseDto = cartService.updateCartItem(cartItemId, authUser, requestDto);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/request/UpdateCartItemRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/request/UpdateCartItemRequestDto.java
@@ -1,0 +1,16 @@
+package com.delivery.igo.igo_delivery.api.cart.dto.request;
+
+import com.delivery.igo.igo_delivery.api.cart.entity.CartItemQuantityType;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateCartItemRequestDto {
+
+    // 증가 - INCREASE
+    // 감소 - DECREASE
+    @NotBlank
+    private final CartItemQuantityType actionType;
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/response/FindAllCartsResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/response/FindAllCartsResponseDto.java
@@ -1,6 +1,5 @@
 package com.delivery.igo.igo_delivery.api.cart.dto.response;
 
-import com.delivery.igo.igo_delivery.api.cart.entity.CartItems;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/response/UpdateCartItemResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/response/UpdateCartItemResponseDto.java
@@ -8,5 +8,5 @@ import lombok.Getter;
 public class UpdateCartItemResponseDto {
 
     private final Long id;
-    private final int Quantity;
+    private final int quantity;
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/response/UpdateCartItemResponseDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/response/UpdateCartItemResponseDto.java
@@ -1,0 +1,12 @@
+package com.delivery.igo.igo_delivery.api.cart.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateCartItemResponseDto {
+
+    private final Long id;
+    private final int Quantity;
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/entity/CartItemQuantityType.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/entity/CartItemQuantityType.java
@@ -1,0 +1,30 @@
+package com.delivery.igo.igo_delivery.api.cart.entity;
+
+import com.delivery.igo.igo_delivery.api.cart.repository.CartItemsRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CartItemQuantityType {
+    INCREASE("수량 증가") {
+        @Override
+        public void apply(CartItems cartItems, CartItemsRepository cartItemsRepository) {
+            cartItems.increaseQuantity();
+        }
+    },
+    DECREASE("수량 감소") {
+        @Override
+        public void apply(CartItems cartItems, CartItemsRepository cartItemsRepository) {
+            cartItems.decreaseQuantity();
+            if (cartItems.isQuantityZero()) {
+                cartItemsRepository.delete(cartItems);
+            }
+        }
+    };
+
+    private final String description;
+
+    public abstract void apply(CartItems cartItems, CartItemsRepository cartItemsRepository);
+
+}

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/entity/CartItems.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/entity/CartItems.java
@@ -1,7 +1,6 @@
 package com.delivery.igo.igo_delivery.api.cart.entity;
 
 import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
-import com.delivery.igo.igo_delivery.api.user.entity.Users;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/entity/CartItems.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/entity/CartItems.java
@@ -49,4 +49,16 @@ public class CartItems {
     public long totalPrice() {
         return cartPrice * cartQuantity.longValue();
     }
+
+    public void increaseQuantity() {
+        cartQuantity++;
+    }
+
+    public void decreaseQuantity() {
+        cartQuantity--;
+    }
+
+    public boolean isQuantityZero() {
+        return cartQuantity <= 0;
+    }
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartService.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartService.java
@@ -1,8 +1,10 @@
 package com.delivery.igo.igo_delivery.api.cart.service;
 
 import com.delivery.igo.igo_delivery.api.cart.dto.request.CreateCartRequestDto;
+import com.delivery.igo.igo_delivery.api.cart.dto.request.UpdateCartItemRequestDto;
 import com.delivery.igo.igo_delivery.api.cart.dto.response.CreateCartResponseDto;
 import com.delivery.igo.igo_delivery.api.cart.dto.response.FindAllCartsResponseDto;
+import com.delivery.igo.igo_delivery.api.cart.dto.response.UpdateCartItemResponseDto;
 import com.delivery.igo.igo_delivery.common.dto.AuthUser;
 
 public interface CartService {
@@ -10,4 +12,6 @@ public interface CartService {
     CreateCartResponseDto addCart(AuthUser authUser, CreateCartRequestDto request);
 
     FindAllCartsResponseDto findAllCarts(AuthUser authUser);
+
+    UpdateCartItemResponseDto updateCartItem(Long cartItemId, AuthUser authUser, UpdateCartItemRequestDto requestDto);
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImpl.java
@@ -99,6 +99,12 @@ public class CartServiceImpl implements CartService{
     @Override
     @Transactional
     public UpdateCartItemResponseDto updateCartItem(Long cartItemId, AuthUser authUser, UpdateCartItemRequestDto requestDto) {
+
+        Users users = userRepository.findById(authUser.getId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+        users.validateAccess(authUser.getId());
+        users.validateConsumer();
+
         CartItems findCartItem = cartItemsRepository.findById(cartItemId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.CART_ITEM_NOT_FOUND));
 

--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImpl.java
@@ -1,9 +1,12 @@
 package com.delivery.igo.igo_delivery.api.cart.service;
 
 import com.delivery.igo.igo_delivery.api.cart.dto.request.CreateCartRequestDto;
+import com.delivery.igo.igo_delivery.api.cart.dto.request.UpdateCartItemRequestDto;
 import com.delivery.igo.igo_delivery.api.cart.dto.response.CartItemResponseDto;
 import com.delivery.igo.igo_delivery.api.cart.dto.response.CreateCartResponseDto;
 import com.delivery.igo.igo_delivery.api.cart.dto.response.FindAllCartsResponseDto;
+import com.delivery.igo.igo_delivery.api.cart.dto.response.UpdateCartItemResponseDto;
+import com.delivery.igo.igo_delivery.api.cart.entity.CartItemQuantityType;
 import com.delivery.igo.igo_delivery.api.cart.entity.CartItems;
 import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
 import com.delivery.igo.igo_delivery.api.cart.repository.CartItemsRepository;
@@ -91,6 +94,18 @@ public class CartServiceImpl implements CartService{
         long totalCartPrice = findCartItems.stream().mapToLong(CartItems::totalPrice).sum();
 
         return FindAllCartsResponseDto.of(carts.getId(), totalCartPrice, responseCartItems);
+    }
+
+    @Override
+    @Transactional
+    public UpdateCartItemResponseDto updateCartItem(Long cartItemId, AuthUser authUser, UpdateCartItemRequestDto requestDto) {
+        CartItems findCartItem = cartItemsRepository.findById(cartItemId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.CART_ITEM_NOT_FOUND));
+
+        CartItemQuantityType actionType = requestDto.getActionType();
+        actionType.apply(findCartItem, cartItemsRepository);
+
+        return new UpdateCartItemResponseDto(findCartItem.getId(), findCartItem.getCartQuantity());
     }
 
 }

--- a/src/main/java/com/delivery/igo/igo_delivery/api/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/order/service/OrderServiceImpl.java
@@ -55,7 +55,7 @@ public class OrderServiceImpl implements OrderService{
         // 장바구니 물건 목록 호출
         List<CartItems> cartItems = cartItemsRepository.findAllByCarts(carts);
         // 장바구니가 비어있을 경우 에러 출력
-        if (cartItems.isEmpty()) throw new GlobalException(ErrorCode.CART_ITEM_NOT_FOUND);
+        if (cartItems.isEmpty()) throw new GlobalException(ErrorCode.CART_NOT_FOUND);
 
         // 해당 매장 정보 호출
         Stores stores = cartItems.get(0).getMenus().getStores();

--- a/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/user/service/UserServiceImpl.java
@@ -78,7 +78,7 @@ public class UserServiceImpl implements UserService {
             throw new GlobalException(ErrorCode.PASSWORD_NOT_MATCHED);
         }
         Carts carts = cartRepository.findByUsers(users)
-                .orElseThrow(() -> new GlobalException(ErrorCode.CART_ITEM_NOT_FOUND));
+                .orElseThrow(() -> new GlobalException(ErrorCode.CART_NOT_FOUND));
 
         cartItemsRepository.deleteAllByCarts(carts);
         cartRepository.delete(carts);

--- a/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
 
     // Common -> default 용도
     DUPLICATED(HttpStatus.BAD_REQUEST, "중복 되었습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청값 입니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "잘못된 접근입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "대상을 찾을 수 없습니다."),
 
@@ -56,8 +57,9 @@ public enum ErrorCode {
     ROLE_CONSUMER_FORBIDDEN(HttpStatus.UNAUTHORIZED, "주문 고객이 아닙니다."),
     ROLE_OWNER_FORBIDDEN(HttpStatus.UNAUTHORIZED, "매장 사장님이 아닙니다."),
 
-    // CartItem
-    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다."),
+    // CartItem, Cart
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다."),
+    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니에 담긴 상품을 찾을 수 없습니다."),
 
     // Store
     NOT_OWNER(HttpStatus.FORBIDDEN, "사장님 권한이 아닙니다."),

--- a/src/test/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImplIntegrationTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImplIntegrationTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImplIntegrationTest.java
+++ b/src/test/java/com/delivery/igo/igo_delivery/api/cart/service/CartServiceImplIntegrationTest.java
@@ -1,0 +1,180 @@
+package com.delivery.igo.igo_delivery.api.cart.service;
+
+import com.delivery.igo.igo_delivery.IgoDeliveryApplication;
+import com.delivery.igo.igo_delivery.api.cart.dto.request.UpdateCartItemRequestDto;
+import com.delivery.igo.igo_delivery.api.cart.dto.response.UpdateCartItemResponseDto;
+import com.delivery.igo.igo_delivery.api.cart.entity.CartItemQuantityType;
+import com.delivery.igo.igo_delivery.api.cart.entity.CartItems;
+import com.delivery.igo.igo_delivery.api.cart.entity.Carts;
+import com.delivery.igo.igo_delivery.api.cart.repository.CartItemsRepository;
+import com.delivery.igo.igo_delivery.api.cart.repository.CartRepository;
+import com.delivery.igo.igo_delivery.api.menu.entity.MenuStatus;
+import com.delivery.igo.igo_delivery.api.menu.entity.Menus;
+import com.delivery.igo.igo_delivery.api.menu.repository.MenuRepository;
+import com.delivery.igo.igo_delivery.api.store.entity.StoreStatus;
+import com.delivery.igo.igo_delivery.api.store.entity.Stores;
+import com.delivery.igo.igo_delivery.api.store.repository.StoreRepository;
+import com.delivery.igo.igo_delivery.api.user.entity.UserRole;
+import com.delivery.igo.igo_delivery.api.user.entity.UserStatus;
+import com.delivery.igo.igo_delivery.api.user.entity.Users;
+import com.delivery.igo.igo_delivery.api.user.repository.UserRepository;
+import com.delivery.igo.igo_delivery.common.dto.AuthUser;
+import com.delivery.igo.igo_delivery.common.exception.ErrorCode;
+import com.delivery.igo.igo_delivery.common.exception.GlobalException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Time;
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = IgoDeliveryApplication.class)
+@Transactional
+@ActiveProfiles("test")
+class CartServiceImplIntegrationTest {
+
+    @Autowired
+    private CartService cartService;
+
+    @Autowired
+    private CartItemsRepository cartItemsRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CartRepository cartRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private MenuRepository menuRepository;
+
+    private Users user1;
+    private Users user2;
+    private Carts carts;
+    private Menus menu;
+    private CartItems cartItem;
+    private AuthUser authUser;
+
+    @BeforeEach
+    void init() {
+        user1 = userRepository.save(Users.builder()
+                .email("test1@example.com")
+                .nickname("테스트유저1")
+                .password("encodedPassword123")
+                .phoneNumber("010-2222-33333")
+                .address("테스트 동네")
+                .userRole(UserRole.CONSUMER)
+                .userStatus(UserStatus.LIVE)
+                .build());
+
+        user2 = userRepository.save(Users.builder()
+                .email("test2@example.com")
+                .nickname("테스트유저2")
+                .password("encodedPassword123")
+                .phoneNumber("010-2222-33333")
+                .address("테스트 동네")
+                .userRole(UserRole.OWNER)
+                .userStatus(UserStatus.LIVE)
+                .build());
+
+        authUser = new AuthUser(
+                user1.getId(),
+                user1.getEmail(),
+                user1.getNickname(),
+                user1.getUserRole()
+        );
+
+        Stores store = Stores.builder()
+                .users(user2)
+                .storeName("테스트가게")
+                .storeAddress("테스트동네")
+                .storePhoneNumber("010-2222-3333")
+                .openTime(Time.valueOf(LocalTime.of(8, 0)))
+                .endTime(Time.valueOf(LocalTime.of(22, 0)))
+                .minOrderPrice(10000)
+                .storeStatus(StoreStatus.OPEN)
+                .avgRating(0.0)
+                .reviewCount(0)
+                .build();
+
+        Stores saveStore = storeRepository.save(store);
+
+        carts = cartRepository.save(Carts.builder()
+                .users(user1)
+                .build());
+
+        menu = menuRepository.save(Menus.builder()
+                .menuName("pizza")
+                .price(10000L)
+                .menuStatus(MenuStatus.LIVE)
+                .stores(saveStore)
+                .build());
+
+        cartItem = cartItemsRepository.save(CartItems.builder()
+                .carts(carts)
+                .menus(menu)
+                .cartPrice(10000L)
+                .cartQuantity(2)
+                .build());
+    }
+
+    @Test
+    void 장바구니아이템의_수량을_2개에서_3개로_증가_성공() {
+        // given
+        UpdateCartItemRequestDto requestDto = new UpdateCartItemRequestDto(CartItemQuantityType.INCREASE);
+
+        // when
+        UpdateCartItemResponseDto responseDto = cartService.updateCartItem(cartItem.getId(), authUser, requestDto);
+
+        // then
+        CartItems updatedCartItem = cartItemsRepository.findById(cartItem.getId()).orElseThrow();
+        assertEquals(3, updatedCartItem.getCartQuantity());
+        assertEquals(responseDto.getId(), cartItem.getId());
+        assertEquals(3, responseDto.getQuantity());
+    }
+
+    @Test
+    void 장바구니아이템의_수량을_1개에서_0개로_감소하면_삭제_성공() {
+        // given
+        cartItem = cartItemsRepository.save(CartItems.builder()
+                .carts(carts)
+                .menus(menu)
+                .cartPrice(10000L)
+                .cartQuantity(1)
+                .build());
+
+        UpdateCartItemRequestDto requestDto = new UpdateCartItemRequestDto(CartItemQuantityType.DECREASE);
+
+        // when
+        cartService.updateCartItem(cartItem.getId(), authUser, requestDto);
+
+        // then
+        boolean result = cartItemsRepository.findById(cartItem.getId()).isPresent();
+        assertFalse(result);
+    }
+
+
+    @Test
+    void 실패하면_장바구니아이템_수량_변경되지_않음_예외_CART_ITEM_NOT_FOUND() {
+        // given
+        long wrongCartItemId = 999999L;
+
+        // when & then
+        GlobalException exception = assertThrows(GlobalException.class,
+                () -> cartService.updateCartItem(wrongCartItemId, authUser, new UpdateCartItemRequestDto(CartItemQuantityType.INCREASE)));
+
+        CartItems findCartItem = cartItemsRepository.findById(cartItem.getId()).orElseThrow();
+
+        assertEquals(ErrorCode.CART_ITEM_NOT_FOUND, exception.getErrorCode());
+        assertEquals(findCartItem.getCartQuantity(), cartItem.getCartQuantity());
+    }
+}


### PR DESCRIPTION
## Description
1. 장바구니 아이템 수량 수정 API 개발
    - 요청값으로 INCREASE가 넘어 오면 수량을 증가
    - 요청값으로 DECREASE가 넘어 오면 수량을 감소
    - 수량 감소시 수량이 0이 되면 DB에서 해당 아이템을 삭제
    - 본인이 아니거나, 고객이 아니라면 예외 발생
    - 찾으려는 장바구니 아이템이 없으면 예외 발생
    - 증가/감소 동작을 관리하는 Enum클래스를 만들어서 이를 통해서 동작하도록 작성

2. 테스트
    - 변경감지를 이용하므로 통합테스트로 실시
    - 정상 수량 증가 케이스
    - 정상 수량 감소 및 삭제 케이스
    - 오류 발생 시 롤백 케이스

3. 추가 작업
    - 관련 에러코드 추가 및 기존 에러코드 수정(장바구니 에러 관련 이름 중복)

## Changes
1. CartController, CartServiceImpl, Carts 수정
2. 관련 요청/응답 Dto 생성
3. CartItemQuantityType Enum 생성
4. CartServiceImplIntegrationTest 생성


