### PR TITLE
Feat [Orders] 주문 생성, 주문 상태 변경 응답 시 log 생성

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/order/dto/ChangeOrderStatusResponse.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/order/dto/ChangeOrderStatusResponse.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 public class ChangeOrderStatusResponse {
 
     private Long orderId;
+    private Long storeId;
     private String nickname;
     private OrderStatus orderStatus;
     private String orderAddress;
@@ -20,9 +21,10 @@ public class ChangeOrderStatusResponse {
     private LocalDateTime modifiedAt;
 
 
-    public static ChangeOrderStatusResponse from(Orders orders) {
+    public static ChangeOrderStatusResponse from(Orders orders, Long storeId) {
         return new ChangeOrderStatusResponse(
                 orders.getId(),
+                storeId,
                 orders.getUsers().getNickname(),
                 orders.getOrderStatus(),
                 orders.getOrderAddress(),

--- a/src/main/java/com/delivery/igo/igo_delivery/api/order/dto/OrderResponse.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/order/dto/OrderResponse.java
@@ -14,6 +14,7 @@ import java.util.List;
 public class OrderResponse {
     //주문 ID, 유저 닉네임, 주문한 메뉴 목록(메뉴명, 가격, 수량 포함), 주문상태, 배송지, 주문일자&수정일
     private Long id;
+    private Long storeId;
     private String nickname;
     private List<OrderItemsResponse> orderItemResponse;
     private OrderStatus orderStatus;
@@ -21,7 +22,8 @@ public class OrderResponse {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public static OrderResponse from(Orders orders, List<OrderItems> orderItems) {
+
+    public static OrderResponse from(Orders orders, List<OrderItems> orderItems, Long storeId) {
         //응답할 orderItemsDto 생성 (메뉴명, 가격, 수량)
         List<OrderItemsResponse> OrderItemResponse = orderItems.stream()
                 .map(item -> new OrderItemsResponse(
@@ -32,6 +34,7 @@ public class OrderResponse {
                 .toList();
         return new OrderResponse(
                 orders.getId(),
+                storeId,
                 orders.getUsers().getNickname(),
                 OrderItemResponse,
                 orders.getOrderStatus(),

--- a/src/main/java/com/delivery/igo/igo_delivery/api/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/order/service/OrderServiceImpl.java
@@ -90,7 +90,7 @@ public class OrderServiceImpl implements OrderService{
         orderItemsRepository.saveAll(orderItems);
         //주문 성공시 장바구니 메뉴 목록 삭제
         cartItemsRepository.deleteAll(cartItems);
-        return OrderResponse.from(orders,orderItems);
+        return OrderResponse.from(orders,orderItems, stores.getId());
     }
 
     //주문상태 변경
@@ -116,7 +116,8 @@ public class OrderServiceImpl implements OrderService{
                 throw new GlobalException(ErrorCode.CONSUMER_CANNOT_CHANGE_STATUS);
             }
             orders.changeStatus(requestStatus);
-            return ChangeOrderStatusResponse.from(orders);
+            Stores stores = orderItemsRepository.findByOrdersId(orders.getId()).get(0).getMenus().getStores();
+            return ChangeOrderStatusResponse.from(orders, stores.getId());
         }
         // 요쳥한 유저가 매장 주인인 경우
         if (authUser.getUserRole() == UserRole.OWNER) {
@@ -129,7 +130,7 @@ public class OrderServiceImpl implements OrderService{
                 throw new GlobalException(ErrorCode.OWNER_CANNOT_CANCEL_ORDER);
             }
             orders.changeStatus(requestStatus);
-            return ChangeOrderStatusResponse.from(orders);
+            return ChangeOrderStatusResponse.from(orders, stores.getId());
         }
         throw new GlobalException(ErrorCode.INVALID_USER_ROLE);
     }
@@ -158,7 +159,8 @@ public class OrderServiceImpl implements OrderService{
                 .allMatch(ownerId -> ownerId.equals(authUser.getId()));
 
         if (isOrderUser || isStoreOwner) {
-            return OrderResponse.from(orders,orderItems);
+            Stores stores = orderItems.get(0).getMenus().getStores();
+            return OrderResponse.from(orders,orderItems,stores.getId());
         }
         throw new GlobalException(ErrorCode.FORBIDDEN);
     }

--- a/src/main/java/com/delivery/igo/igo_delivery/common/config/OrderLogAspect.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/common/config/OrderLogAspect.java
@@ -1,0 +1,53 @@
+package com.delivery.igo.igo_delivery.common.config;
+
+import com.delivery.igo.igo_delivery.api.order.dto.ChangeOrderStatusResponse;
+import com.delivery.igo.igo_delivery.api.order.dto.OrderResponse;
+import com.delivery.igo.igo_delivery.api.order.entity.OrderStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class OrderLogAspect {
+
+
+    @Pointcut("execution(* com.delivery.igo.igo_delivery.api.order.service.OrderService.createOrder(..)) " +
+            "|| execution(* com.delivery.igo.igo_delivery.api.order.service.OrderService.changeOrderStatus(..))")
+    public void orderMethods() {}
+
+    @AfterReturning(pointcut = "orderMethods()", returning = "result")
+    public void logOrder(JoinPoint joinPoint, Object result) {
+        // 요청 시각
+        LocalDateTime now = LocalDateTime.now();
+
+        Long orderId = null;
+        Long storeId = null;
+        OrderStatus orderStatus = null;
+
+        if (result instanceof OrderResponse orderResponse) {
+            // 주문 생성 응답 처리
+            orderId = orderResponse.getId();
+            storeId = orderResponse.getStoreId();
+        } else if (result instanceof ChangeOrderStatusResponse changeOrderStatusResponse) {
+            // 주문 상태 변경 응답 처리
+            orderId = changeOrderStatusResponse.getOrderId();
+            storeId = changeOrderStatusResponse.getStoreId();
+            orderStatus = changeOrderStatusResponse.getOrderStatus();
+        }
+
+        if (orderStatus != null) {
+            log.info("[주문 상태 변경] 시간: {}, 주문ID: {}, 가게ID: {}, 주문 상태: {}", now, orderId, storeId, orderStatus);
+        } else {
+            log.info("[주문 생성] 시간: {}, 주문ID: {}, 가게ID: {}", now, orderId, storeId);
+        }
+    }
+}


### PR DESCRIPTION

## Description
- 주문 요청, 주문 상태 변경 응답 로그 추가
- 해당 api가 실행 될 때만 로그 출력
- 응답 시간, 주문ID, 가게ID, 주문 상태(상태변경 api만) 출력
## Changes
- 주문 요청, 주문 상태 응답 관련 dto 필드에 storeId 추가
- 관련 api 명세서도 수정
## Screenshots
![image](https://github.com/user-attachments/assets/55a2d01f-180f-4786-a9b7-436b0a621a55)
주문 요청시 응답 로그
![image](https://github.com/user-attachments/assets/3f64471f-f762-4116-9aed-5f2e02e13d1c)
주문 상태 변경시 응답 로그

