### PR TITLE
[Cart] 장바구니 수량 증가/감소 API에 잘못된 Bean Validation 애노테이션 적용된것을 수정

### DIFF
--- a/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/request/UpdateCartItemRequestDto.java
+++ b/src/main/java/com/delivery/igo/igo_delivery/api/cart/dto/request/UpdateCartItemRequestDto.java
@@ -1,7 +1,7 @@
 package com.delivery.igo.igo_delivery.api.cart.dto.request;
 
 import com.delivery.igo.igo_delivery.api.cart.entity.CartItemQuantityType;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,6 +11,6 @@ public class UpdateCartItemRequestDto {
 
     // 증가 - INCREASE
     // 감소 - DECREASE
-    @NotBlank
+    @NotNull
     private final CartItemQuantityType actionType;
 }


### PR DESCRIPTION
## Description
-  장바구니 수량/증가 API 감소 Dto의 Enum 타입 필드에 @NotBlank 적용된 부분을 @NotNull로 수정
- NotBlank는 String에서만 사용가능함

## Changes
- UpdateCartItemRequestDto